### PR TITLE
Reponse can modify Cache-Control and Expires headers

### DIFF
--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -854,8 +854,6 @@ bool Connection::sendResponse(std::shared_ptr<Response> response) {
 
     if(headers.find("Cache-Control") == headers.end()) {
         bufferLine("Cache-Control: no-store");
-    }else {
-        std::cout << "FOUND";
     }
 
     if(headers.find("Expires") == headers.end()) {

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -852,11 +852,11 @@ bool Connection::sendResponse(std::shared_ptr<Response> response) {
     bufferLine("Last-Modified: " + now());
     bufferLine("Pragma: no-cache");
 
-    if(headers.find("Cache-Control") == headers.end()) {
+    if (headers.find("Cache-Control") == headers.end()) {
         bufferLine("Cache-Control: no-store");
     }
 
-    if(headers.find("Expires") == headers.end()) {
+    if (headers.find("Expires") == headers.end()) {
         bufferLine("Expires: " + now());
     }
 

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -839,6 +839,8 @@ bool Connection::sendResponse(std::shared_ptr<Response> response) {
         return sendError(response->responseCode(), response->payload());
     }
 
+    auto headers = response->getAdditionalHeaders();
+
     bufferResponseAndCommonHeaders(response->responseCode());
     bufferLine("Content-Length: " + toString(response->payloadSize()));
     bufferLine("Content-Type: " + response->contentType());
@@ -848,13 +850,22 @@ bool Connection::sendResponse(std::shared_ptr<Response> response) {
         bufferLine("Connection: close");
     }
     bufferLine("Last-Modified: " + now());
-    bufferLine("Cache-Control: no-store");
     bufferLine("Pragma: no-cache");
-    bufferLine("Expires: " + now());
-    auto headers = response->getAdditionalHeaders();
+
+    if(headers.find("Cache-Control") == headers.end()) {
+        bufferLine("Cache-Control: no-store");
+    }else {
+        std::cout << "FOUND";
+    }
+
+    if(headers.find("Expires") == headers.end()) {
+        bufferLine("Expires: " + now());
+    }
+
     for (auto it = headers.begin(); it != headers.end(); ++it) {
         bufferLine(it->first + ": " + it->second);
     }
+
     bufferLine("");
 
     if (!write(response->payload(), response->payloadSize(), true)) {


### PR DESCRIPTION
I need to controll Cache-Control for Response. For now, I made this changes.

What do you think?

Maybe I find better solution to add this headers as two atributes to seasocks::Response class with default values no-store and Expires = now().