### PR TITLE
Install compilers through Travis Apt-addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,8 @@ language: cpp
 compiler:
   - gcc
   - clang
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:h-rayflood/llvm -y
-  - sudo apt-get update -qq
 install:
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.7; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
-  - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq --allow-unauthenticated clang-3.4; fi
-  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.4" CC="clang-3.4"; fi
   - wget "https://googlemock.googlecode.com/files/gmock-1.7.0.zip"
   - unzip gmock-1.7.0.zip
   - sudo apt-get install valgrind
@@ -19,3 +12,10 @@ script:
   - ./configure --with-gmock=gmock-1.7.0
   - make
   - make test
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-4.7
+            - g++-4.7


### PR DESCRIPTION
Install compilers through Travis Apt-addon.

Unfortunately, `sudo` is still required for installing valgrind, without it would be possible to run on (faster) travis containers. 