### PR TITLE
Installing valgrind using apt addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: cpp
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
   - wget "https://googlemock.googlecode.com/files/gmock-1.7.0.zip"
   - unzip gmock-1.7.0.zip
-  - sudo apt-get install valgrind
 script:
   - autoconf
   - ./configure --with-gmock=gmock-1.7.0
@@ -19,3 +18,4 @@ addons:
         packages:
             - gcc-4.7
             - g++-4.7
+            - valgrind


### PR DESCRIPTION
Just an addition to #12. Valgrind is installed through addon too - the build can run in a container.