### PR TITLE
CMake added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /.gmock
 .gdb_history
 gdb.txt
+build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,23 @@ language: cpp
 compiler:
   - gcc
   - clang
+env:
+  - TOOL=autoconf
+  - TOOL=cmake
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
   - wget "https://googlemock.googlecode.com/files/gmock-1.7.0.zip"
   - unzip gmock-1.7.0.zip
 script:
-  - autoconf
-  - ./configure --with-gmock=gmock-1.7.0
-  - make
-  - make test
+  - if [ "$TOOL" = "autoconf" ]; then autoconf && ./configure --with-gmock=gmock-1.7.0 && make && make test; fi
+  - if [ "$TOOL" = "cmake" ]; then mkdir build && cd build && cmake .. && make; fi
 addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
+            - kalakris-cmake
         packages:
             - gcc-4.7
             - g++-4.7
             - valgrind
+            - cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(EmbeddedContent)
 include(CompilerCheck)
 
+include(GNUInstallDirs)
+
 configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 
 add_definitions(-Wall -std=c++11 -DSEASOCKS_VERSION_STRING=\"${PROJECT_VERSION}\")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(EmbeddedContent)
 
 
+configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 
 add_definitions(-std=c++11)
-include_directories("src/main/c")
+include_directories("src/main/c"
+                    ${CMAKE_BINARY_DIR}
+                    )
 
 add_subdirectory("src/main/c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+project(Seasocks)
+# TODO: Version
+
+add_definitions(-std=c++11)
+
+################################################################################
+set(WEB_DIR "${CMAKE_SOURCE_DIR}/src/main/web")
+set(EMBEDDED_CONTENT_FILE "${CMAKE_BINARY_DIR}/Embedded.cpp")
+set(SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_embedded.py")
+set(PYTHON "python2") ## TODO Find correct Python
+
+
+file(GLOB _EMBEDDED_FILES "${WEB_DIR}/*")
+list(APPEND _EMBEDDED_FILES "${CMAKE_SOURCE_DIR}/src/main/c/internal/Embedded.h")
+
+#string(REPLACE ";" " " EMBEDDED_FILES "${_EMBEDDED_FILES}") ### XXX: Obsolete?
+
+
+
+
+add_custom_command(OUTPUT Embedded.cpp
+    COMMAND ${PYTHON} ${SCRIPT} ${_EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
+
+BYPRODUCTS Embedded.cpp
+
+COMMENT "Generate embedded content"
+)
+
+add_custom_target(embedded ALL
+    DEPENDS Embedded.cpp)
+
+
+
+
+#add_custom_command(OUTPUT output1 [output2 ...]
+#                   COMMAND command1 [ARGS] [args1...]
+#                   [COMMAND command2 [ARGS] [args2...] ...]
+#                   [MAIN_DEPENDENCY depend]
+#                   [DEPENDS [depends...]]
+#                   [BYPRODUCTS [files...]]
+#                   [IMPLICIT_DEPENDS <lang1> depend1
+#                                    [<lang2> depend2] ...]
+#                   [WORKING_DIRECTORY dir]
+#                   [COMMENT comment]
+#                   [VERBATIM] [APPEND] [USES_TERMINAL])
+
+
+#execute_process(COMMAND 
+#    ${PYTHON} ${SCRIPT} ${_EMBEDDED_FILES}
+#    RESULT_VARIABLE _R
+##    OUTPUT_VARIABLE _O
+#    OUTPUT_FILE "${EMBEDDED_CONTENT_FILE}"
+#    )
+
+#file(WRITE ${EMBEDDED_CONTENT_FILE} "${_O}")
+
+################################################################################
+
+
+include_directories("src/main/c")
+add_subdirectory("src/main/c")
+
+
+#EMBEDDED_CONTENT:=$(shell find src/main/web -type f)
+#$(OBJ_DIR)/embedded.o: scripts/gen_embedded.py $(EMBEDDED_CONTENT) src/main/c/internal/Embedded.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,67 +1,15 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0)
 
-project(Seasocks)
-# TODO: Version
+project(Seasocks VERSION 1.1.6)
+
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(EmbeddedContent)
+
+
 
 add_definitions(-std=c++11)
-
-################################################################################
-set(WEB_DIR "${CMAKE_SOURCE_DIR}/src/main/web")
-set(EMBEDDED_CONTENT_FILE "${CMAKE_BINARY_DIR}/Embedded.cpp")
-set(SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_embedded.py")
-set(PYTHON "python2") ## TODO Find correct Python
-
-
-file(GLOB _EMBEDDED_FILES "${WEB_DIR}/*")
-list(APPEND _EMBEDDED_FILES "${CMAKE_SOURCE_DIR}/src/main/c/internal/Embedded.h")
-
-#string(REPLACE ";" " " EMBEDDED_FILES "${_EMBEDDED_FILES}") ### XXX: Obsolete?
-
-
-
-
-add_custom_command(OUTPUT Embedded.cpp
-    COMMAND ${PYTHON} ${SCRIPT} ${_EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
-
-BYPRODUCTS Embedded.cpp
-
-COMMENT "Generate embedded content"
-)
-
-add_custom_target(embedded ALL
-    DEPENDS Embedded.cpp)
-
-
-
-
-#add_custom_command(OUTPUT output1 [output2 ...]
-#                   COMMAND command1 [ARGS] [args1...]
-#                   [COMMAND command2 [ARGS] [args2...] ...]
-#                   [MAIN_DEPENDENCY depend]
-#                   [DEPENDS [depends...]]
-#                   [BYPRODUCTS [files...]]
-#                   [IMPLICIT_DEPENDS <lang1> depend1
-#                                    [<lang2> depend2] ...]
-#                   [WORKING_DIRECTORY dir]
-#                   [COMMENT comment]
-#                   [VERBATIM] [APPEND] [USES_TERMINAL])
-
-
-#execute_process(COMMAND 
-#    ${PYTHON} ${SCRIPT} ${_EMBEDDED_FILES}
-#    RESULT_VARIABLE _R
-##    OUTPUT_VARIABLE _O
-#    OUTPUT_FILE "${EMBEDDED_CONTENT_FILE}"
-#    )
-
-#file(WRITE ${EMBEDDED_CONTENT_FILE} "${_O}")
-
-################################################################################
-
-
 include_directories("src/main/c")
+
 add_subdirectory("src/main/c")
-
-
-#EMBEDDED_CONTENT:=$(shell find src/main/web -type f)
-#$(OBJ_DIR)/embedded.o: scripts/gen_embedded.py $(EMBEDDED_CONTENT) src/main/c/internal/Embedded.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,4 @@ include_directories("src/main/c"
                     )
 
 add_subdirectory("src/main/c")
+add_subdirectory("src/app/c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Seasocks VERSION 1.1.6)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(EmbeddedContent)
-
+include(CompilerCheck)
 
 configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ include(CompilerCheck)
 
 configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 
-add_definitions(-std=c++11)
+add_definitions(-Wall -std=c++11)
+
 include_directories("src/main/c"
                     ${CMAKE_BINARY_DIR}
                     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,15 @@ message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION}")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+option(UNITTESTS "Build unittests." OFF)
+message(STATUS "Unittests: ${UNITTESTS}")
+
+
 include(EmbeddedContent)
 include(CompilerCheck)
 
 include(GNUInstallDirs)
+
 
 configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 
@@ -22,3 +27,15 @@ include_directories("src/main/c"
 
 add_subdirectory("src/main/c")
 add_subdirectory("src/app/c")
+
+find_package(Threads)
+
+
+if( UNITTESTS )
+    find_package(gmock REQUIRED)
+    find_package(gtest REQUIRED)
+
+    enable_testing()
+    add_subdirectory("src/test/c")
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.11)
 
-project(Seasocks VERSION 1.1.6)
+project(Seasocks)
+set(PROJECT_VERSION 1.1.6)
 
 message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(Seasocks VERSION 1.1.6)
 
+message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION}")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -10,7 +11,7 @@ include(CompilerCheck)
 
 configure_file(${CMAKE_MODULE_PATH}/Config.h.in internal/Config.h)
 
-add_definitions(-Wall -std=c++11)
+add_definitions(-Wall -std=c++11 -DSEASOCKS_VERSION_STRING=\"${PROJECT_VERSION}\")
 
 include_directories("src/main/c"
                     ${CMAKE_BINARY_DIR}

--- a/cmake/CompilerCheck.cmake
+++ b/cmake/CompilerCheck.cmake
@@ -1,0 +1,25 @@
+
+set(TEMP_DIR "${CMAKE_BINARY_DIR}/temp")
+
+file(WRITE ${TEMP_DIR}/TestUnorderedMap.cpp 
+"#include <unordered_map>\n
+int main(void)
+{
+    std::unordered_map<int, int> a;
+    a.emplace(2, 3);
+    
+    return 0;
+}\n\n"
+)
+
+try_compile(HAVE_UNORDERED_MAP_EMPLACE ${TEMP_DIR} 
+                    ${TEMP_DIR}/TestUnorderedMap.cpp
+                    COMPILE_DEFINITIONS -std=c++11
+                    )
+
+if( HAVE_UNORDERED_MAP_EMPLACE )
+    set(HAVE_UNORDERED_MAP_EMPLACE 1)
+else()
+    set(HAVE_UNORDERED_MAP_EMPLACE 0)
+endif()
+

--- a/cmake/Config.h.in
+++ b/cmake/Config.h.in
@@ -1,0 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+
+
+#endif /* CONFIG_H */

--- a/cmake/Config.h.in
+++ b/cmake/Config.h.in
@@ -1,6 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-
+/* HAVE_UNORDERED_MAP_EMPLACE */
+#cmakedefine HAVE_UNORDERED_MAP_EMPLACE      @HAVE_UNORDERED_MAP_EMPLACE@
 
 #endif /* CONFIG_H */

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -13,4 +13,3 @@ add_custom_command(OUTPUT Embedded.cpp
                         )
 
 add_Library(embedded Embedded.cpp)
-

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -1,0 +1,18 @@
+
+
+set(SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_embedded.py")
+set(PYTHON "python2") ## TODO Find correct Python
+
+
+file(GLOB EMBEDDED_FILES "src/main/web/*")
+list(APPEND EMBEDDED_FILES "${CMAKE_SOURCE_DIR}/src/main/c/internal/Embedded.h")
+
+
+
+add_custom_command(OUTPUT Embedded.cpp
+                        COMMAND ${PYTHON} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
+                        BYPRODUCTS Embedded.cpp
+                        COMMENT "Generate embedded content"
+                        )
+
+add_custom_target(embedded ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Embedded.cpp)

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -5,8 +5,6 @@ set(PYTHON "python2")
 
 
 file(GLOB EMBEDDED_FILES "src/main/web/*")
-list(APPEND EMBEDDED_FILES "${CMAKE_SOURCE_DIR}/src/main/c/internal/Embedded.h")
-
 
 
 add_custom_command(OUTPUT Embedded.cpp
@@ -14,4 +12,4 @@ add_custom_command(OUTPUT Embedded.cpp
                         COMMENT "Generate embedded content"
                         )
 
-add_Library(embedded Embedded.cpp)
+add_Library(embedded STATIC Embedded.cpp)

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -1,7 +1,7 @@
 
 
 set(SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_embedded.py")
-set(PYTHON "python2") ## TODO Find correct Python
+set(PYTHON "python2")
 
 
 file(GLOB EMBEDDED_FILES "src/main/web/*")
@@ -15,4 +15,4 @@ add_custom_command(OUTPUT Embedded.cpp
                         COMMENT "Generate embedded content"
                         )
 
-add_custom_target(embedded ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Embedded.cpp)
+add_Library(embedded Embedded.cpp)

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -11,7 +11,6 @@ list(APPEND EMBEDDED_FILES "${CMAKE_SOURCE_DIR}/src/main/c/internal/Embedded.h")
 
 add_custom_command(OUTPUT Embedded.cpp
                         COMMAND ${PYTHON} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
-                        BYPRODUCTS Embedded.cpp
                         COMMENT "Generate embedded content"
                         )
 

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -8,7 +8,7 @@ file(GLOB EMBEDDED_FILES "src/main/web/*")
 
 add_custom_command(OUTPUT Embedded.cpp
                         COMMAND ${PYTHON} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
-                        COMMENT "Generate embedded content"
+                        COMMENT "Generating embedded content"
                         )
 
 add_library(embedded OBJECT Embedded.cpp)

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -12,4 +12,5 @@ add_custom_command(OUTPUT Embedded.cpp
                         COMMENT "Generate embedded content"
                         )
 
-add_Library(embedded STATIC Embedded.cpp)
+add_Library(embedded Embedded.cpp)
+

--- a/cmake/EmbeddedContent.cmake
+++ b/cmake/EmbeddedContent.cmake
@@ -1,5 +1,4 @@
 
-
 set(SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_embedded.py")
 set(PYTHON "python2")
 
@@ -12,4 +11,4 @@ add_custom_command(OUTPUT Embedded.cpp
                         COMMENT "Generate embedded content"
                         )
 
-add_Library(embedded Embedded.cpp)
+add_library(embedded OBJECT Embedded.cpp)

--- a/cmake/Findgmock.cmake
+++ b/cmake/Findgmock.cmake
@@ -1,0 +1,23 @@
+
+find_package(PkgConfig)
+pkg_check_modules(PKG_gmock QUIET gmock)
+
+set(gmock_DEFINITIONS ${PKG_gmock_CFLAGS_OTHER})
+
+find_path(gmock_INCLUDE_DIR "gmock/gmock.h"
+                            HINTS ${PKG_gmock_INCLUDE_DIRS}
+                            PATH_SUFFIXES "gmock"
+                            )
+find_library(gmock_LIBRARY NAMES gmock
+                            HINTS ${PKG_gmock_LIBDIR} ${PKG_gmock_LIBRARY_DIRS}
+                            )
+
+set(gmock_LIBRARIES ${gmock_LIBRARY})
+set(gmock_INCLUDE_DIRS ${gmock_INCLUDE_DIR})
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(gmock DEFAULT_MSG gmock_LIBRARY gmock_INCLUDE_DIRS)
+
+mark_as_advanced(gmock_INCLUDE_DIR gmock_LIBRARY)
+

--- a/cmake/Findgtest.cmake
+++ b/cmake/Findgtest.cmake
@@ -1,0 +1,23 @@
+
+find_package(PkgConfig)
+pkg_check_modules(PKG_gtest QUIET gtest)
+
+set(gtest_DEFINITIONS ${PKG_gtest_CLFAGS_OTHER})
+
+find_path(gtest_INCLUDE_DIR "gtest/gtest.h"
+                            HINTS ${PKG_gtest_INCLUDE_DIRS}
+                            PATH_SUFFIXES "gtest"
+                            )
+find_library(gtest_LIBRARY NAMES gtest
+                            HINTS ${PKG_gtest_LIBDIR} ${PKG_gtest_LIBRARY_DIRS}
+                            )
+
+set(gtest_LIBRARIES ${gtest_LIBRARY})
+set(gtest_INCLUDE_DIRS ${gtest_INCLUDE_DIR})
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(gmock DEFAULT_MSG gtest_LIBRARY gtest_INCLUDE_DIRS)
+
+mark_as_advanced(gtest_INCLUDE_DIR gmock_LIBRARY)
+ 

--- a/src/app/c/CMakeLists.txt
+++ b/src/app/c/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+macro(add_app _NAME})
+    add_executable(${ARGV0} ${ARGV0}.cpp)
+    target_link_libraries(${ARGV0} seasocks)
+endmacro()
+
+
+add_app(ph_test)
+add_app(serve)
+add_app(ws_echo)
+add_app(ws_test)
+add_app(ws_test_poll)
+

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -1,29 +1,23 @@
 
-#if( NOT EXISTS ${EMBEDDED_CONTENT_FILE} )
-#    message(SEND_ERROR "No embedded content file  found: '${EMBEDDED_CONTENT_FILE}'")
-#endif()
-
-add_library(seasocks ./HybiAccept.cpp
-    ./StringUtil.cpp
-    ./Server.cpp
-    ./internal/Base64.cpp
-    ./Connection.cpp
-    ./HybiPacketDecoder.cpp
-    ./PageRequest.cpp
-    ./Logger.cpp
-    ./Response.cpp
-    ./md5/md5.cpp
-    ./util/CrackedUri.cpp
-    ./util/Json.cpp
-    ./util/PathHandler.cpp
-    ./util/RootPageHandler.cpp
-    ./sha1/sha1.cpp
-    ./seasocks/ResponseCode.cpp
-    ./seasocks/ResponseBuilder.cpp
-    ./seasocks/Request.cpp
-
-    ${EMBEDDED_CONTENT_FILE}
-
-        )
+add_library(seasocks ${CMAKE_BINARY_DIR}/Embedded.cpp
+                        HybiAccept.cpp
+                        StringUtil.cpp
+                        Server.cpp
+                        internal/Base64.cpp
+                        Connection.cpp
+                        HybiPacketDecoder.cpp
+                        PageRequest.cpp
+                        Logger.cpp
+                        Response.cpp
+                        md5/md5.cpp
+                        util/CrackedUri.cpp
+                        util/Json.cpp
+                        util/PathHandler.cpp
+                        util/RootPageHandler.cpp
+                        sha1/sha1.cpp
+                        seasocks/ResponseCode.cpp
+                        seasocks/ResponseBuilder.cpp
+                        seasocks/Request.cpp
+                        )
 
 add_dependencies(seasocks embedded)

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-add_library(seasocks ${CMAKE_BINARY_DIR}/Embedded.cpp
-                        HybiAccept.cpp
+add_library(seasocks HybiAccept.cpp
                         StringUtil.cpp
                         Server.cpp
                         internal/Base64.cpp
@@ -20,4 +19,5 @@ add_library(seasocks ${CMAKE_BINARY_DIR}/Embedded.cpp
                         seasocks/Request.cpp
                         )
 
-add_dependencies(seasocks embedded)
+target_link_libraries(seasocks embedded)                    
+

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -1,4 +1,3 @@
-aux_source_directory(${CMAKE_BINARY_DIR} GENERATED_SRC)
 
 add_library(seasocks HybiAccept.cpp
                         StringUtil.cpp
@@ -19,8 +18,5 @@ add_library(seasocks HybiAccept.cpp
                         seasocks/ResponseBuilder.cpp
                         seasocks/Request.cpp
 
-                        ${GENERATED_SRC}
+                        $<TARGET_OBJECTS:embedded>
                         )
-
-target_link_libraries(seasocks embedded)                    
-

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -20,3 +20,16 @@ add_library(seasocks HybiAccept.cpp
 
                         $<TARGET_OBJECTS:embedded>
                         )
+
+
+
+install(TARGETS seasocks
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                )
+install(DIRECTORY seasocks
+                    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                    FILES_MATCHING PATTERN "*.h"
+                    )
+

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -1,0 +1,29 @@
+
+#if( NOT EXISTS ${EMBEDDED_CONTENT_FILE} )
+#    message(SEND_ERROR "No embedded content file  found: '${EMBEDDED_CONTENT_FILE}'")
+#endif()
+
+add_library(seasocks ./HybiAccept.cpp
+    ./StringUtil.cpp
+    ./Server.cpp
+    ./internal/Base64.cpp
+    ./Connection.cpp
+    ./HybiPacketDecoder.cpp
+    ./PageRequest.cpp
+    ./Logger.cpp
+    ./Response.cpp
+    ./md5/md5.cpp
+    ./util/CrackedUri.cpp
+    ./util/Json.cpp
+    ./util/PathHandler.cpp
+    ./util/RootPageHandler.cpp
+    ./sha1/sha1.cpp
+    ./seasocks/ResponseCode.cpp
+    ./seasocks/ResponseBuilder.cpp
+    ./seasocks/Request.cpp
+
+    ${EMBEDDED_CONTENT_FILE}
+
+        )
+
+add_dependencies(seasocks embedded)

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -1,3 +1,4 @@
+aux_source_directory(${CMAKE_BINARY_DIR} GENERATED_SRC)
 
 add_library(seasocks HybiAccept.cpp
                         StringUtil.cpp
@@ -17,6 +18,8 @@ add_library(seasocks HybiAccept.cpp
                         seasocks/ResponseCode.cpp
                         seasocks/ResponseBuilder.cpp
                         seasocks/Request.cpp
+
+                        ${GENERATED_SRC}
                         )
 
 target_link_libraries(seasocks embedded)                    

--- a/src/test/c/CMakeLists.txt
+++ b/src/test/c/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+set(TESTS "AllTests")
+
+add_executable(AllTests test_main.cpp
+                        ConnectionTests.cpp 
+                        CrackedUriTests.cpp
+                        HeaderMapTests.cpp
+                        HtmlTests.cpp
+                        HybiTests.cpp
+                        JsonTests.cpp
+                        MockServerImpl.h
+                        )
+
+add_test(NAME ${TESTS} COMMAND ${TESTS})
+target_include_directories(${TESTS} PUBLIC ${gtest_INCLUDE_DIRS}
+                                            ${gmock_INCLUDE_DIRS}
+                                            ${CMAKE_CURRENT_SOURCE_DIR}
+                                            )
+target_link_libraries(${TESTS} ${gtest_LIBRARIES} 
+                                ${gmock_LIBRARIES}
+                                ${CMAKE_THREAD_LIBS_INIT}
+                                seasocks
+                                )


### PR DESCRIPTION
This PR addes cmake as a second build tool.

### Available:

- Building of library and apps
- Installation using `make install`
- Travis CI (Matrix using both)
- Generation of embedded content
- Testing compiler for `emplace()`
- Optional building / running of tests using gtest / gmock (default: `OFF`)
- Configure file - `Config.h` (based on a custom template in `cmake/`)

### Not (yet) available:
- Building tests on CI using cmake

Since google has merged gtest / gmock into one project - gmock depends on gtest though - i'm not sure how to handle this case on CI. It seems gmock requires gtest but doesn't ship it anymore in one bundle (?).

At the moment cmake will look for both if tests are enabled, otherwise there's no dependency on gtest / gmock if disabled.

### What's different to autoconf:

The cmake builds will use it's own `Config.h` (`cmake` directory); it has only a definition for `HAVE_UNORDERED_MAP_EMPLACE`, since i didn't see any usage of all the other flags. However, adding more options is simple enough.
