### PR TITLE
NULL replaced by nullptr

### DIFF
--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -30,7 +30,7 @@ print """
 const EmbeddedContent* findEmbeddedContent(const std::string& name) {
 	auto found = embedded.find(name);
 	if (found == embedded.end()) {
-		return NULL;
+		return nullptr;
 	}
 	return &found->second;
 }

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -73,7 +73,7 @@ uint32_t parseWebSocketKey(const std::string& key) {
     return numSpaces > 0 ? keyNumber / numSpaces : 0;
 }
 
-char* extractLine(uint8_t*& first, uint8_t* last, char** colon = NULL) {
+char* extractLine(uint8_t*& first, uint8_t* last, char** colon = nullptr) {
     for (uint8_t* ptr = first; ptr < last - 1; ++ptr) {
         if (ptr[0] == '\r' && ptr[1] == '\n') {
             ptr[0] = 0;
@@ -81,11 +81,11 @@ char* extractLine(uint8_t*& first, uint8_t* last, char** colon = NULL) {
             first = ptr + 2;
             return reinterpret_cast<char*> (result);
         }
-        if (colon && ptr[0] == ':' && *colon == NULL) {
+        if (colon && ptr[0] == ':' && *colon == nullptr) {
             *colon = reinterpret_cast<char*> (ptr);
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 std::string webtime(time_t time) {
@@ -98,7 +98,7 @@ std::string webtime(time_t time) {
 }
 
 std::string now() {
-    return webtime(time(NULL));
+    return webtime(time(nullptr));
 }
 
 class RaiiFd {
@@ -720,7 +720,7 @@ bool Connection::processHeaders(uint8_t* first, uint8_t* last) {
     // Be careful about lifetimes though and multiple requests coming in, should
     // we ever support HTTP pipelining and/or long-lived requests.
     char* requestLine = extractLine(first, last);
-    assert(requestLine != NULL);
+    assert(requestLine != nullptr);
 
     LS_ACCESS(_logger, "Request: " << requestLine);
 
@@ -733,12 +733,12 @@ bool Connection::processHeaders(uint8_t* first, uint8_t* last) {
         return sendBadRequest("Malformed request line");
     }
     const char* requestUri = shift(requestLine);
-    if (requestUri == NULL) {
+    if (requestUri == nullptr) {
         return sendBadRequest("Malformed request line");
     }
 
     const char* httpVersion = shift(requestLine);
-    if (httpVersion == NULL) {
+    if (httpVersion == nullptr) {
         return sendBadRequest("Malformed request line");
     }
     if (strcmp(httpVersion, "HTTP/1.1") != 0) {
@@ -750,10 +750,10 @@ bool Connection::processHeaders(uint8_t* first, uint8_t* last) {
 
     HeaderMap headers(31);
     while (first < last) {
-        char* colonPos = NULL;
+        char* colonPos = nullptr;
         char* headerLine = extractLine(first, last, &colonPos);
-        assert(headerLine != NULL);
-        if (colonPos == NULL) {
+        assert(headerLine != nullptr);
+        if (colonPos == nullptr) {
             return sendBadRequest("Malformed header");
         }
         *colonPos = 0;

--- a/src/main/c/Server.cpp
+++ b/src/main/c/Server.cpp
@@ -287,7 +287,7 @@ void Server::checkAndDispatchEpoll(int epollMillis) {
     }
     if (numEvents == maxEvents) {
         static time_t lastWarnTime = 0;
-        time_t now = time(NULL);
+        time_t now = time(nullptr);
         if (now - lastWarnTime >= 60) {
             LS_WARNING(_logger, "Full event queue; may start starving connections. "
                     "Will warn at most once a minute");
@@ -397,7 +397,7 @@ void Server::processEventQueue() {
         if (!runnable) break;
         runnable->run();
     }
-    time_t now = time(NULL);
+    time_t now = time(nullptr);
     if (now >= _nextDeadConnectionCheck) {
         std::list<Connection*> toRemove;
         for (auto it = _connections.cbegin(); it != _connections.cend(); ++it) {
@@ -438,7 +438,7 @@ void Server::handleAccept() {
         ::close(fd);
         return;
     }
-    _connections.insert(std::make_pair(newConnection, time(NULL)));
+    _connections.insert(std::make_pair(newConnection, time(nullptr)));
 }
 
 void Server::remove(Connection* connection) {

--- a/src/main/c/StringUtil.cpp
+++ b/src/main/c/StringUtil.cpp
@@ -46,13 +46,13 @@ char* skipNonWhitespace(char* str) {
 }
 
 char* shift(char*& str) {
-    if (str == NULL) {
-        return NULL;
+    if (str == nullptr) {
+        return nullptr;
     }
     char* startOfWord = skipWhitespace(str);
     if (*startOfWord == 0) {
         str = startOfWord;
-        return NULL;
+        return nullptr;
     }
     char* endOfWord = skipNonWhitespace(startOfWord);
     if (*endOfWord != 0) {

--- a/src/main/c/internal/PageRequest.h
+++ b/src/main/c/internal/PageRequest.h
@@ -70,7 +70,7 @@ public:
     }
 
     virtual const uint8_t* content() const {
-        return _contentLength > 0 ? &_content[0] : NULL;
+        return _contentLength > 0 ? &_content[0] : nullptr;
     }
 
     virtual bool hasHeader(const std::string& name) const {

--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -71,7 +71,7 @@ public:
     virtual const std::string& getRequestUri() const override;
     virtual Request::Verb verb() const override { return Request::WebSocket; }
     virtual size_t contentLength() const override { return 0; }
-    virtual const uint8_t* content() const override { return NULL; }
+    virtual const uint8_t* content() const override { return nullptr; }
     virtual bool hasHeader(const std::string&) const override;
     virtual std::string getHeader(const std::string&) const override;
 


### PR DESCRIPTION
Since C++11 is checked, it's safe to use `nullptr` now.