### PR TITLE
Parameter name used in the macro

### DIFF
--- a/src/app/c/CMakeLists.txt
+++ b/src/app/c/CMakeLists.txt
@@ -1,6 +1,6 @@
-macro(add_app _NAME})
-    add_executable(${ARGV0} ${ARGV0}.cpp)
-    target_link_libraries(${ARGV0} seasocks)
+macro(add_app _NAME)
+    add_executable(${_NAME} ${_NAME}.cpp)
+    target_link_libraries(${_NAME} seasocks)
 endmacro()
 
 


### PR DESCRIPTION
Just the parameter name used instead of `${ARGV0}` in the cmake macro.