### PR TITLE
toString() for integral types implemented using std::to_string().

### DIFF
--- a/src/main/c/seasocks/ToString.h
+++ b/src/main/c/seasocks/ToString.h
@@ -31,11 +31,7 @@
 
 namespace seasocks {
 
-template<typename T>
-constexpr bool isIntegralType = std::is_integral<typename std::decay<T>::type>::value;
-
-
-template<typename T, typename std::enable_if<!isIntegralType<T>, int>::type = 0>
+template<typename T, typename std::enable_if<!std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
 std::string toString(const T& obj) {
     std::stringstream str;
     str.imbue(std::locale("C"));
@@ -43,7 +39,7 @@ std::string toString(const T& obj) {
     return str.str();
 }
 
-template<typename T, typename std::enable_if<isIntegralType<T>, int>::type = 0>
+template<typename T, typename std::enable_if<std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
 inline std::string toString(T&& value) {
     return std::to_string(std::forward<T>(value));
 }

--- a/src/main/c/seasocks/ToString.h
+++ b/src/main/c/seasocks/ToString.h
@@ -27,16 +27,37 @@
 
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 namespace seasocks {
 
-// TODO: can this be deprecated in favour of std::to_string now?
 template<typename T>
+constexpr bool isIntegralType = std::is_integral<typename std::decay<T>::type>::value;
+
+
+template<typename T, typename std::enable_if<!isIntegralType<T>, int>::type = 0>
 std::string toString(const T& obj) {
     std::stringstream str;
     str.imbue(std::locale("C"));
     str << obj;
     return str.str();
+}
+
+template<typename T, typename std::enable_if<isIntegralType<T>, int>::type = 0>
+inline std::string toString(T&& value) {
+    return std::to_string(std::forward<T>(value));
+}
+
+inline std::string toString(const char* str) {
+    return str;
+}
+
+inline std::string toString(const std::string& str) {
+    return str;
+}
+
+inline std::string toString(char c) {
+    return std::string(1, c);
 }
 
 }

--- a/src/test/c/HtmlTests.cpp
+++ b/src/test/c/HtmlTests.cpp
@@ -56,6 +56,11 @@ TEST_CASE("shouldAppendLikeAStreamFromEmpty", "[HtmlTests]") {
     CHECK(elem.str() == "Text 1 10.23");
 }
 
+TEST_CASE("shouldAppendLikeAStreamFromEmptyWithSingleInt", "[HtmlTests]") {
+    auto elem = empty() << 1;
+    CHECK(elem.str() == "1");
+}
+
 TEST_CASE("shouldNotNeedExtraMarkupForTextNodes", "[HtmlTests]") {
     auto elem = text("This ") << text("is") << text(" a test") << ".";
     CHECK(elem.str() == "This is a test.");

--- a/src/test/c/ToStringTests.cpp
+++ b/src/test/c/ToStringTests.cpp
@@ -29,11 +29,25 @@
 
 using namespace seasocks;
 
-TEST_CASE("insensitiveToLocale", "[toStringTests]") {
-    CHECK(toString(1234) == "1234");
-    auto prev = std::locale::global(std::locale("en_US.utf8"));
-    CHECK(toString(1234) == "1234"); // locale-dependent could have been 1,234
-    std::locale::global(std::locale(""));
-    CHECK(toString(1234) == "1234"); // locale-dependent could have been 1,234
-    std::locale::global(prev);
+TEST_CASE("withIntegralTypes", "[toStringTests]") {
+    CHECK(toString(static_cast<short>(1234)) == "1234");
+    CHECK(toString(static_cast<unsigned short>(1234)) == "1234");
+
+    CHECK(toString(static_cast<int>(1234)) == "1234");
+    CHECK(toString(static_cast<unsigned int>(1234)) == "1234");
+
+    CHECK(toString(static_cast<long>(1234)) == "1234");
+    CHECK(toString(static_cast<unsigned long>(1234)) == "1234");
+
+    CHECK(toString(static_cast<long long>(1234)) == "1234");
+    CHECK(toString(static_cast<unsigned long long>(1234)) == "1234");
+}
+
+TEST_CASE("withFloatTypes", "[toStringTests]") {
+    CHECK(toString(123.4) == "123.4");
+    CHECK(toString(123.4f) == "123.4");
+}
+
+TEST_CASE("withCharType" "[toStringTests]") {
+    CHECK(toString('c') == "c");
 }


### PR DESCRIPTION
This adds template specializations for integral- and string types.

The failing test of #31 is replaced by some new.