### PR TITLE
Support listening on AF_UNIX sockets

### DIFF
--- a/src/main/c/seasocks/Server.h
+++ b/src/main/c/seasocks/Server.h
@@ -82,6 +82,10 @@ public:
     // Returns true if all was ok.
     bool startListening(int port);
 
+    // Starts listening on a unix domain socket.
+    // Returns true if all was ok.
+    bool startListeningUnix(const char* socketPath);
+
     // Sets the path to server static content from.
     void setStaticPath(const char* staticPath);
 


### PR DESCRIPTION
Thanks for Seasocks, works great for me so far!

This patch adds a method `startListeningUnix` to `Server` that lets the server listen on unix domain sockets as well as internet sockets.

My motivation for the patch is that I will have many servers running (one for each customer) and rather than allocate port numbers for each one and maintain a mapping from customer ID to port number, I would rather use the filesystem hierarchy for this organisation. I will use nginx to reverse proxy the connections to Seasocks.

The info line that Seasocks logs:

    info: Listening on unix socket: http://unix:/var/eventstore/ws.socket

is nginx-compatible, ie:

    location /ws/ {
        proxy_pass http://unix:/var/eventstore/ws.socket;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $connection_upgrade;
    }

* In `configureSocket` it sets `SO_REUSEADDR` which I don't believe has any effect on AF_UNIX sockets (but doesn't break anything)
* However, calling `setMaxKeepAliveDrops` will probably cause `configureSocket` to fail for unix sockets since it tries to set `IPPROTO_TCP` options. I suppose we could detect `_maxKeepAliveDrops` > 0 somewhere or other and throw an error but personally I feel this isn't a big deal and people should just not do that.
* Some code was copied from `startListening` into `startListeningUnix`. If you think it's worthwhile to factor out the `listen`/`epoll_ctl` stuff let me know.