### PR TITLE
Enum changed to scoped enum

### DIFF
--- a/src/main/c/seasocks/Server.h
+++ b/src/main/c/seasocks/Server.h
@@ -145,7 +145,7 @@ private:
 
     void checkAndDispatchEpoll(int epollMillis);
     void handlePipe();
-    enum NewState { KeepOpen, Close };
+    enum class NewState { KeepOpen, Close };
     NewState handleConnectionEvents(Connection* connection, uint32_t events);
 
     // Connections, mapped to initial connection time.


### PR DESCRIPTION
State-Enum changed to scoped enum. As the enum is used internally only, there's no API change.

@mattgodbolt There are still some non-scoped enums left. Though changing them to scoped could case an API change as `log(DEBUG, "abc")` becomes `log(Level::DEBUG, "abc")`. Therefore I haven't changed them – what's your take on that?