### PR TITLE
Fixes for shadowed variables

### DIFF
--- a/src/app/c/ws_test.cpp
+++ b/src/app/c/ws_test.cpp
@@ -75,8 +75,8 @@ public:
         int value = atoi(data) + 1;
         if (value > _currentValue) {
             setValue(value);
-            for (auto connection : _connections) {
-                connection->send(_currentSetValue.c_str());
+            for (auto c : _connections) {
+                c->send(_currentSetValue.c_str());
             }
         }
     }

--- a/src/app/c/ws_test_poll.cpp
+++ b/src/app/c/ws_test_poll.cpp
@@ -81,8 +81,8 @@ public:
         int value = atoi(data) + 1;
         if (value > _currentValue) {
             setValue(value);
-            for (auto connection : _connections) {
-                connection->send(_currentSetValue.c_str());
+            for (auto c : _connections) {
+                c->send(_currentSetValue.c_str());
             }
         }
     }

--- a/src/main/c/Server.cpp
+++ b/src/main/c/Server.cpp
@@ -51,7 +51,7 @@ namespace {
 
 struct EventBits {
     uint32_t bits;
-    explicit EventBits(uint32_t bits) : bits(bits) {}
+    explicit EventBits(uint32_t b) : bits(b) {}
 };
 
 std::ostream& operator <<(std::ostream& o, const EventBits& b) {

--- a/src/main/c/internal/LogStream.h
+++ b/src/main/c/internal/LogStream.h
@@ -32,9 +32,9 @@
 
 #define LS_LOG(LOG, LEVEL, STUFF) \
 { \
-    std::ostringstream o; \
-    o << STUFF; \
-    (LOG)->log(Logger::Level::LEVEL, o.str().c_str()); \
+    std::ostringstream os_; \
+    os_ << STUFF; \
+    (LOG)->log(Logger::Level::LEVEL, os_.str().c_str()); \
 }
 
 #define LS_DEBUG(LOG, STUFF)     LS_LOG(LOG, DEBUG, STUFF)

--- a/src/main/c/seasocks/util/Json.h
+++ b/src/main/c/seasocks/util/Json.h
@@ -145,7 +145,7 @@ static_assert(is_jsonable<JsonnedString>::value, "Internal stream problem");
 
 struct EpochTimeAsLocal {
     time_t t;
-    EpochTimeAsLocal(time_t t) : t(t) {}
+    EpochTimeAsLocal(time_t time) : t(time) {}
     void jsonToStream(std::ostream &o) const;
 };
 static_assert(is_jsonable<EpochTimeAsLocal>::value, "Internal stream problem");

--- a/src/test/c/ServerTests.cpp
+++ b/src/test/c/ServerTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Server tests", "[ServerTests]") {
     SECTION("many executes") {
         std::atomic<bool> latch(false);
         for (auto i = 0; i < 100; ++i) {
-            for (auto i = 0; i < 100; ++i) {
+            for (auto j = 0; j < 100; ++j) {
                 server.execute([&] { test++; });
             }
             usleep(10);


### PR DESCRIPTION
Some shadowed variables fixed.

-----------------------

Unfortunately adding `-Wshadow` to the CI builds ends in blood and thunder, because all compiler at Travis will warn about methods hiding parameter with the same identifier.