### PR TITLE
Search and check python executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,15 @@ include_directories(${CMAKE_BINARY_DIR})
 
 add_definitions(-Wall -Werror -Wextra -pedantic -ggdb3)
 
-
 find_package(Threads)
+
+
+find_program(PYTHON_BIN python2 DOC "Python executable")
+
+if( NOT PYTHON_BIN )
+    message(SEND_ERROR "Python not found")
+endif()
+
 
 add_subdirectory("src/main/c")
 add_subdirectory("src/main/web")

--- a/src/main/web/CMakeLists.txt
+++ b/src/main/web/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(SCRIPT "${PROJECT_SOURCE_DIR}/scripts/gen_embedded.py")
-set(PYTHON "python2")
 
 
 set(EMBEDDED_FILES 
@@ -14,7 +13,7 @@ set(EMBEDDED_FILES
 
 
 add_custom_command(OUTPUT Embedded.cpp
-                        COMMAND ${PYTHON} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
+                        COMMAND ${PYTHON_BIN} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
                         COMMENT "Generating embedded content"
                         )
 add_library(embedded STATIC Embedded.cpp)


### PR DESCRIPTION
Search and check python executable. This will cause an error if `python2` is not installed. In addition the path can be changed through command line / CMake Gui.