### PR TITLE
Per-message deflate as described in RFC 7692

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if( NOT PYTHON_BIN )
 endif()
 
 
+find_package(ZLIB REQUIRED)
+
+
 add_subdirectory("src/main/c")
 add_subdirectory("src/main/web")
 add_subdirectory("src/app/c")
@@ -43,4 +46,3 @@ if (UNITTESTS)
     enable_testing()
     add_subdirectory("src/test/c")
 endif ()
-

--- a/src/app/c/CMakeLists.txt
+++ b/src/app/c/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(add_app _NAME)
     add_executable(${_NAME} ${_NAME}.cpp)
-    target_link_libraries(${_NAME} seasocks)
+    target_link_libraries(${_NAME} seasocks "${ZLIB_LIBRARIES}")
 endmacro()
 
 add_app(ph_test)

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -28,8 +28,8 @@ target_include_directories(seasocks PUBLIC .)
 target_link_libraries(seasocks PRIVATE ${CMAKE_THREAD_LIBS_INIT} embedded)
 
 add_library(seasocks_so SHARED $<TARGET_OBJECTS:seasocks_obj>)
-target_include_directories(seasocks_so PUBLIC .)
-target_link_libraries(seasocks_so PRIVATE ${CMAKE_THREAD_LIBS_INIT} embedded)
+target_include_directories(seasocks_so PUBLIC ${ZLIB_INCLUDE_DIRS} .)
+target_link_libraries(seasocks_so PRIVATE ${CMAKE_THREAD_LIBS_INIT} embedded "${ZLIB_LIBRARIES}")
 set_target_properties(seasocks_so PROPERTIES OUTPUT_NAME seasocks)
 
 install(TARGETS seasocks seasocks_so

--- a/src/main/c/Server.cpp
+++ b/src/main/c/Server.cpp
@@ -592,6 +592,11 @@ void Server::setMaxKeepAliveDrops(int maxKeepAliveDrops) {
     _maxKeepAliveDrops = maxKeepAliveDrops;
 }
 
+void Server::setPerMessageDeflateEnabled(bool enabled) {
+    LS_INFO(_logger, "Setting per-message deflate to " << (enabled ? "enabled" : "disabled"));
+    _perMessageDeflateEnabled = enabled;
+}
+
 void Server::checkThread() const {
     auto thisTid = gettid();
     if (thisTid != _threadId) {

--- a/src/main/c/internal/HybiPacketDecoder.h
+++ b/src/main/c/internal/HybiPacketDecoder.h
@@ -59,7 +59,11 @@ public:
         Pong,
         Close
     };
-    MessageState decodeNextMessage(std::vector<uint8_t>& messageOut);
+    MessageState decodeNextMessage(std::vector<uint8_t>& messageOut, bool& deflateNeeded);
+    MessageState decodeNextMessage(std::vector<uint8_t>& messageOut) {
+        bool ignore;
+        return decodeNextMessage(messageOut, ignore);
+    }
 
     size_t numBytesDecoded() const;
 };

--- a/src/main/c/internal/ZlibContext.h
+++ b/src/main/c/internal/ZlibContext.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <zlib.h>
+
+#include <vector>
+#include <stdexcept>
+
+
+namespace seasocks {
+
+class ZlibContext {
+public:
+    ZlibContext(const ZlibContext&) = delete;
+    ZlibContext& operator=(const ZlibContext&) = delete;
+
+    ZlibContext(int deflateBits=15, int inflateBits=15, int memLevel=6) {
+        int ret;
+
+        deflateStream.zalloc = Z_NULL;
+        deflateStream.zfree = Z_NULL;
+        deflateStream.opaque = Z_NULL;
+
+        ret = ::deflateInit2(
+            &deflateStream,
+            Z_DEFAULT_COMPRESSION,
+            Z_DEFLATED,
+            deflateBits * -1,
+            memLevel,
+            Z_DEFAULT_STRATEGY
+        );
+
+        if (ret != Z_OK) {
+            throw std::runtime_error("error initialising zlib deflater");
+        }
+
+        inflateStream.zalloc = Z_NULL;
+        inflateStream.zfree = Z_NULL;
+        inflateStream.opaque = Z_NULL;
+        inflateStream.avail_in = 0;
+        inflateStream.next_in = Z_NULL;
+
+        ret = ::inflateInit2(
+            &inflateStream,
+            inflateBits * -1
+        );
+
+        if (ret != Z_OK) {
+            ::deflateEnd(&deflateStream);
+            throw std::runtime_error("error initialising zlib inflater");
+        }
+
+        streamsInitialised = true;
+    }
+
+    ~ZlibContext() {
+        if (!streamsInitialised) return;
+        ::deflateEnd(&deflateStream);
+        ::inflateEnd(&inflateStream);
+    }
+
+    void deflate(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output) {
+        deflateStream.next_in = (unsigned char *)input;
+        deflateStream.avail_in = inputLen;
+
+        do {
+            deflateStream.next_out = buffer;
+            deflateStream.avail_out = sizeof(buffer);
+
+            (void) ::deflate(&deflateStream, Z_SYNC_FLUSH);
+
+            output.insert(output.end(), buffer, buffer + sizeof(buffer) - deflateStream.avail_out);
+        } while (deflateStream.avail_out == 0);
+
+        // Remove 4-byte tail end prior to transmission (see RFC 7692, section 7.2.1)
+        output.resize(output.size() - 4);
+    }
+
+    // WARNING: inflate() alters input
+    bool inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& output, int& zlibError) {
+        // Append 4 octets prior to decompression (see RFC 7692, section 7.2.2)
+        uint8_t tail_end[4] = {0x00, 0x00, 0xff, 0xff};
+        input.insert(input.end(), tail_end, tail_end + 4);
+
+        inflateStream.next_in = input.data();
+        inflateStream.avail_in = input.size();
+
+        do {
+            inflateStream.next_out = buffer;
+            inflateStream.avail_out = sizeof(buffer);
+
+            int ret = ::inflate(&inflateStream, Z_SYNC_FLUSH);
+
+            if (ret != Z_OK && ret != Z_STREAM_END) {
+                zlibError = ret;
+                return false;
+            }
+
+            output.insert(output.end(), buffer, buffer + sizeof(buffer) - inflateStream.avail_out);
+        } while (inflateStream.avail_out == 0);
+
+        return true;
+    }
+
+private:
+    z_stream deflateStream;
+    z_stream inflateStream;
+    bool streamsInitialised = false;
+    uint8_t buffer[16384];
+};
+
+}  // namespace seasocks

--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -30,6 +30,8 @@
 #include "seasocks/ResponseWriter.h"
 #include "seasocks/TransferEncoding.h"
 
+#include "internal/ZlibContext.h"
+
 #include <netinet/in.h>
 
 #include <sys/socket.h>
@@ -126,6 +128,8 @@ private:
 
     void sendHybi(uint8_t opcode, const uint8_t* webSocketResponse,
                   size_t messageLength);
+    void sendHybiData(const uint8_t* webSocketResponse, size_t messageLength);
+
 
     bool sendResponse(std::shared_ptr<Response> response);
 
@@ -176,6 +180,10 @@ private:
     TransferEncoding _transferEncoding;
     unsigned _chunk;
     std::shared_ptr<Writer> _writer;
+
+    void parsePerMessageDeflateHeader(const std::string& header);
+    bool _perMessageDeflate = false;
+    std::unique_ptr<ZlibContext> zlibContext;
 
     enum class State {
         INVALID,

--- a/src/main/c/seasocks/Server.h
+++ b/src/main/c/seasocks/Server.h
@@ -119,6 +119,9 @@ public:
     void setClientBufferSize(size_t bytesToBuffer);
     size_t clientBufferSize() const override { return _clientBufferSize; }
 
+    void setPerMessageDeflateEnabled(bool enabled);
+    bool getPerMessageDeflateEnabled() { return _perMessageDeflateEnabled;}
+
     class Runnable {
     public:
         virtual ~Runnable() {}
@@ -165,6 +168,9 @@ private:
     int _lameConnectionTimeoutSeconds;
     size_t _clientBufferSize;
     time_t _nextDeadConnectionCheck;
+
+    // Compression settings
+    bool _perMessageDeflateEnabled = false;
 
     struct WebSocketHandlerEntry {
         std::shared_ptr<WebSocket::Handler> handler;

--- a/src/test/c/CMakeLists.txt
+++ b/src/test/c/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(AllTests test_main.cpp
         EmbeddedContentTests.cpp)
 
 add_test(NAME ${TESTS} COMMAND ${TESTS})
-target_link_libraries(${TESTS} seasocks)
+target_link_libraries(${TESTS} seasocks "${ZLIB_LIBRARIES}")


### PR DESCRIPTION
Github issue #5

For my work-load (somewhat redundant JSON) it reduces the transmitted
message sizes to nearly 1/10th their uncompressed sizes so it will be
a huge bandwidth saver.

It basically does the bare minimum to be RFC 7692 compatible. I have
tested the compression with chromium and websocketpp 0.7.0 and seasocks
seems to compress/decompress messages properly in both directions.

Current limitations:
  - Can't configure the *_no_context_takeover or *_max_window_bits
    extensions. It will only negotiate the default (context takeover
    and max window bits in both directions)
  - All transmitted messages will be compressed. Ideally you should
    be able to opt-out of compressing particular messages (but it
    does support clients that compress particular messages)
  - Only ever issues one DEFLATE block per message since the
    seasocks API doesn't support incremental message construction
    (but I believe it does support receiving multiple blocks from
    clients that do)
  - Various tuning parameters such as buffer size and memLevel
    are hard-coded. Some apps might like to customise them
  - Requires linking to zlib even if no compression will be used
  - No tests :(