### PR TITLE
Clang 4.0 and some fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
             - llvm-toolchain-precise-3.8
             - llvm-toolchain-precise-3.7
             - llvm-toolchain-precise-3.6
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+              key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     - env: CXX=g++-5 CC=gcc-5
       addons:
         apt:
@@ -48,6 +50,14 @@ matrix:
         apt:
           packages:
             - g++-4.7
+            - valgrind
+          sources: *sources
+    - env: CXX=clang++-4.0 CC=clang-4.0
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+            - libc++-dev
             - valgrind
           sources: *sources
     - env: CXX=clang++-3.9 CC=clang-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: cpp
+language: generic
+
 sudo: false
 dist: trusty
 

--- a/src/test/c/MockServerImpl.h
+++ b/src/test/c/MockServerImpl.h
@@ -53,7 +53,7 @@ public:
     std::string getStatsDocument() const override { return ""; }
     void checkThread() const override { }
     Server &server() override { throw std::runtime_error("not supported"); };
-    size_t clientBufferSize() const { return 512 * 1024; }
+    size_t clientBufferSize() const override { return 512 * 1024; }
 };
 
 }


### PR DESCRIPTION
1. Adds Clang 4.0 ci build (#64)
1. Fixes a build failure on all clang builds (missing `override`)
1. Fixes broken compiler selection on all ci builds (instead of the desired compiler, Gcc 4.8 was always used)