### PR TITLE
Added StreamingResponse

### DIFF
--- a/src/app/c/CMakeLists.txt
+++ b/src/app/c/CMakeLists.txt
@@ -10,6 +10,7 @@ add_app(ws_echo)
 add_app(ws_test)
 add_app(ws_test_poll)
 add_app(async_test)
+add_app(streaming_test)
 
 add_custom_command(TARGET ws_test POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/src/app/c/streaming_test.cpp
+++ b/src/app/c/streaming_test.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2013-2016, Martin Charles
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this 
+// list of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, 
+// this list of conditions and the following disclaimer in the documentation 
+// and/or other materials provided with the distribution.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "seasocks/PageHandler.h"
+#include "seasocks/PrintfLogger.h"
+#include "seasocks/Server.h"
+#include "seasocks/StringUtil.h"
+#include "seasocks/SimpleResponse.h"
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+
+using namespace seasocks;
+
+size_t streamlen(std::shared_ptr<std::istream> stream) {
+    stream->seekg(0, stream->end);
+    size_t len = stream->tellg();
+    stream->seekg(0, stream->beg);
+    return len;
+}
+
+class MyPageHandler: public PageHandler {
+public:
+    virtual std::shared_ptr<Response> handle(const Request& request) {
+        if (request.verb() != Request::Verb::Get) {
+            return Response::unhandled();
+        }
+
+        auto ss = std::make_shared<std::stringstream>();
+        (*ss) << "<html><head><title>seasocks example</title></head>"
+               "<body>Hello, " << request.credentials()->attributes["fullName"] << "! You asked for " << request.getRequestUri()
+               << " and your ip is " << request.getRemoteAddress().sin_addr.s_addr
+               << " and a random number is " << rand()
+               << "</body></html>";
+
+        auto headers = SimpleResponse::Headers({
+            {"Content-Type", "text/html"},
+            {"Content-Length", std::to_string(streamlen(ss))},
+            {"Connection", "keep-alive"},
+        });
+
+        auto response = std::shared_ptr<Response>(new SimpleResponse(
+            ResponseCode::Ok,  // response code
+            ss,                // stream
+            headers,           // headers
+            true,              // keep alive
+            true               // flush instantly
+        ));
+        return response;
+    }
+};
+
+int main(int /*argc*/, const char* /*argv*/[]) {
+    std::shared_ptr<Logger> logger(new PrintfLogger(Logger::Level::INFO));
+
+    Server server(logger);
+    server.addPageHandler(std::make_shared<MyPageHandler>());
+
+    server.serve("", 9090);
+    return 0;
+}

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SEASOCKS_SOURCE_FILES Connection.cpp
                         seasocks/ResponseCode.cpp
                         seasocks/SynchronousResponse.cpp
                         seasocks/ResponseBuilder.cpp
+                        seasocks/StreamingResponse.cpp
                         sha1/sha1.cpp
                         util/CrackedUri.cpp
                         util/Json.cpp

--- a/src/main/c/internal/ConcreteResponse.h
+++ b/src/main/c/internal/ConcreteResponse.h
@@ -35,9 +35,12 @@ class ConcreteResponse : public SynchronousResponse {
     const std::string _contentType;
     const Headers _headers;
     const bool _keepAlive;
+
 public:
-    ConcreteResponse(ResponseCode responseCode, const std::string& payload, const std::string& contentType, const Headers& headers, bool keepAlive) :
-        _responseCode(responseCode), _payload(payload), _contentType(contentType), _headers(headers), _keepAlive(keepAlive) {}
+    ConcreteResponse(ResponseCode responseCode, const std::string& payload,
+        const std::string& contentType, const Headers& headers, bool keepAlive) :
+            _responseCode(responseCode), _payload(payload), _contentType(contentType),
+            _headers(headers), _keepAlive(keepAlive) { }
 
     virtual ResponseCode responseCode() const override {
         return _responseCode;

--- a/src/main/c/seasocks/Response.h
+++ b/src/main/c/seasocks/Response.h
@@ -39,6 +39,8 @@ class Response {
 public:
     virtual ~Response() {}
     virtual void handle(std::shared_ptr<ResponseWriter> writer) = 0;
+
+    // Called when the connection this response is being sent on is closed.
     virtual void cancel() = 0;
 
     static std::shared_ptr<Response> unhandled();

--- a/src/main/c/seasocks/ResponseWriter.h
+++ b/src/main/c/seasocks/ResponseWriter.h
@@ -57,6 +57,7 @@ public:
     virtual void payload(const void* data, size_t size, bool flush=true) = 0;
     // Finish a response.
     virtual void finish(bool keepConnectionOpen) = 0;
+
     // Send an error back to the user. No calls to 'header' or 'payload'
     // or 'finish' should be executed. If you wish to serve your own error document
     // then use the normal 'begin'/'header'/'payload'/'finish' process but with

--- a/src/main/c/seasocks/SimpleResponse.h
+++ b/src/main/c/seasocks/SimpleResponse.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2013-2016, Martin Charles
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "seasocks/StreamingResponse.h"
+
+namespace seasocks {
+
+class SimpleResponse : public StreamingResponse {
+    ResponseCode _responseCode;
+    std::shared_ptr<std::istream> _stream;
+    const Headers _headers;
+    const bool _keepAlive;
+    const bool _flushInstantly;
+    const size_t _bufferSize;
+    const TransferEncoding _transferEncoding;
+
+public:
+    static constexpr size_t DefaultBufferSize = 16 * 1024 * 1024u;
+
+    SimpleResponse(ResponseCode responseCode, std::shared_ptr<std::istream> stream,
+    const Headers& headers, bool keepAlive = true, bool flushInstantly = false,
+    size_t bufferSize = DefaultBufferSize,
+    TransferEncoding transferEncoding = TransferEncoding::Raw):
+        _responseCode(responseCode), _stream(stream), _headers(headers),
+        _keepAlive(keepAlive), _flushInstantly(flushInstantly),
+        _bufferSize(bufferSize), _transferEncoding(transferEncoding) { }
+
+    virtual std::shared_ptr<std::istream> getStream() const override {
+        return _stream;
+    }
+
+    virtual Headers getHeaders() const override {
+        return _headers;
+    }
+
+    virtual ResponseCode responseCode() const override {
+        return _responseCode;
+    }
+
+    virtual bool keepConnectionAlive() const override {
+        return _keepAlive;
+    }
+
+    virtual bool flushInstantly() const override {
+        return _flushInstantly;
+    }
+
+    virtual size_t getBufferSize() const override {
+        return _bufferSize;
+    }
+
+    virtual TransferEncoding transferEncoding() const override {
+        return _transferEncoding;
+    }
+};
+
+}
+

--- a/src/main/c/seasocks/StreamingResponse.cpp
+++ b/src/main/c/seasocks/StreamingResponse.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2013-2016, Martin Charles
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "seasocks/StreamingResponse.h"
+#include "seasocks/ToString.h"
+#include "seasocks/StringUtil.h"
+
+using namespace seasocks;
+
+void StreamingResponse::handle(std::shared_ptr<ResponseWriter> writer) {
+    writer->begin(responseCode(), transferEncoding());
+
+    auto headers = getHeaders();
+    for (auto it = headers.begin(); it != headers.end(); ++it) {
+        writer->header(it->first, it->second);
+    }
+
+    std::shared_ptr<std::istream> stream = getStream();
+
+    auto bufSize = getBufferSize();
+    bool flush = flushInstantly();
+    std::unique_ptr<char[]> buffer(new char[bufSize]);
+
+    while (!closed) {
+        // blocks until buffer is full or eof is reached
+        stream->read(buffer.get(), bufSize);
+
+        bool isEof = stream->eof();
+        bool isGood = stream->good();
+        if (isGood || isEof) {
+            // everything is fine, push data to client
+            writer->payload(buffer.get(), stream->gcount(), flush);
+        }
+
+        if (!isGood) {
+            // EOF or error occured
+            // ignore the error since we can't access it
+            closed = true;
+        }
+    };
+
+    writer->finish(keepConnectionAlive());
+}
+
+void StreamingResponse::cancel() {
+    closed = true;
+}
+

--- a/src/main/c/seasocks/StreamingResponse.h
+++ b/src/main/c/seasocks/StreamingResponse.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2013-2016, Martin Charles
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "seasocks/Response.h"
+#include "seasocks/ResponseWriter.h"
+#include "seasocks/TransferEncoding.h"
+
+#include <iosfwd>
+
+namespace seasocks {
+
+// A low level way to write create responses. This class doesn't meddle with or
+// assume anything based on the headers.
+class StreamingResponse : public Response {
+    bool closed = false;
+
+public:
+    virtual ~StreamingResponse() { }
+    virtual void handle(std::shared_ptr<ResponseWriter> writer) override;
+    virtual void cancel() override;
+
+    virtual std::shared_ptr<std::istream> getStream() const = 0;
+
+    typedef std::multimap <std::string, std::string> Headers;
+    virtual Headers getHeaders() const = 0;
+
+    virtual ResponseCode responseCode() const = 0;
+
+    virtual bool keepConnectionAlive() const = 0;
+    virtual bool flushInstantly() const = 0;
+
+    virtual size_t getBufferSize() const = 0;
+    virtual TransferEncoding transferEncoding() const = 0;
+};
+
+}
+


### PR DESCRIPTION
Hey guys!

I've added a new Response type which doesn't meddle with the before sending it (adding headers, sending errors in the error file template, etc.). It also uses streams to get data.

I plan to use this to remove assumptions the core makes (CORS enabled, Server Name, default file handling, error handling) to make seasocks more flexible while keeping seasocks easy to use.