### PR TITLE
Add SONAME versioning to shared library

### DIFF
--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(seasocks_so PUBLIC ${ZLIB_INCLUDE_DIRS} .)
 if (DEFLATE_SUPPORT)
     target_link_libraries(seasocks_so PRIVATE ${CMAKE_THREAD_LIBS_INIT} "${ZLIB_LIBRARIES}")
 endif()
-set_target_properties(seasocks_so PROPERTIES OUTPUT_NAME seasocks)
+set_target_properties(seasocks_so PROPERTIES OUTPUT_NAME seasocks VERSION ${PROJECT_VERSION})
 
 install(TARGETS seasocks seasocks_so
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Add SONAME versioning to shared library

Shared library files should include their version information, so that the runtime linker knows whether the installed shared library works with the program trying to use it. CMake supports this with the VERSION and SOVERSION properties for shared library targets.

This resolves #77 in the most conservative way possible (with the full version information going into the SONAME), because anything more would require stricter adherence to semantic versioning than this project has historically seen.