### PR TITLE
Python3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,12 @@ endif ()
 find_package(Threads)
 
 
-find_program(PYTHON_BIN python2 DOC "Python executable")
+find_program(PYTHON_BIN python DOC "Python executable")
 
 if (NOT PYTHON_BIN)
     message(SEND_ERROR "Python not found")
+else()
+    message(STATUS "Using Python: '${PYTHON_BIN}'")
 endif ()
 
 if (DEFLATE_SUPPORT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif ()
 find_package(Threads)
 
 
-find_program(PYTHON_BIN python DOC "Python executable")
+find_program(PYTHON_BIN python3 DOC "Python executable")
 
 if (NOT PYTHON_BIN)
     message(SEND_ERROR "Python not found")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif ()
 find_package(Threads)
 
 
-find_program(PYTHON_BIN python3 DOC "Python executable")
+find_program(PYTHON_BIN python DOC "Python executable")
 
 if (NOT PYTHON_BIN)
     message(SEND_ERROR "Python not found")

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -1,9 +1,31 @@
 #!/usr/bin/env python
 
-import os, os.path, sys
+import os, os.path, sys, argparse
 
+SOURCE_INTRO = """
+#include "internal/Embedded.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace {
+"""
+SOURCE_OUTRO = """
+    };
+
+}  // namespace
+
+    const EmbeddedContent* findEmbeddedContent(const std::string& name) {
+        const auto found = embedded.find(name);
+        if (found == embedded.end()) {
+            return nullptr;
+        }
+        return &found->second;
+    }\n
+"""
 
 MAX_SLICE = 70
+
 
 def as_byte(data):
     if sys.version_info < (3,):
@@ -12,46 +34,47 @@ def as_byte(data):
         return data
 
 
-print("""
-#include "internal/Embedded.h"
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Embedded content generator")
+    parser.add_argument('--output', '-o', action='store', dest='output_file', type=str, help='Output File', required=True)
+    parser.add_argument('--file', '-f', action='store', nargs='+', dest='input_file', type=str, help='Output File', required=True)
+    return parser.parse_args()
 
-#include <string>
-#include <unordered_map>
 
-namespace {
-""")
+def write_file_bytes(file, name, file_bytes):
+    file.write('    const char %s[] = {' % name)
 
-files = []
-index = 1
+    for start in range(0, len(file_bytes), MAX_SLICE):
+        file.write('' + "".join(["'\\x%02x'," % as_byte(x) for x in file_bytes[start:start+MAX_SLICE]]) + "\n")
+    file.write('0};\n')
 
-for f in sys.argv[1:]:
-    bytes = open(f, 'rb').read()
-    name = "fileData%d" % index
-    index += 1
-    files.append((name, os.path.basename(f), len(bytes)))
-    print('const char %s[] = {' % name)
-    for start in range(0, len(bytes), MAX_SLICE):
-        print('' + "".join(["'\\x%02x'," % as_byte(x) for x in bytes[start:start+MAX_SLICE]]))
-    print('0 };')
 
-print("""
-std::unordered_map<std::string, EmbeddedContent> embedded = {
-""")
+def write_file_info(file, file_list):
+    for name, base, length in file_list:
+        file.write('        {"/%s", { %s, %d }},\n' % (base, name, length))
 
-for name, base, length in files:
-    print('{"/%s", { %s, %d }},' % (base, name, length))
 
-print("""
-};
+def main():
+    args = parse_arguments()
 
-}  // namespace
+    with open(args.output_file, 'w') as output_file:
+        output_file.write(SOURCE_INTRO)
 
-const EmbeddedContent* findEmbeddedContent(const std::string& name) {
-    const auto found = embedded.find(name);
-    if (found == embedded.end()) {
-        return nullptr;
-    }
-    return &found->second;
-}
-""")
+        files = []
+        index = 1
 
+        for file_name in args.input_file:
+            with open(file_name, 'rb') as f:
+                file_bytes = f.read()
+            name = "fileData%d" % index
+            index += 1
+            files.append((name, os.path.basename(file_name), len(file_bytes)))
+            write_file_bytes(output_file, name, file_bytes)
+
+        output_file.write("\n    std::unordered_map<std::string, EmbeddedContent> embedded = {\n")
+        write_file_info(output_file, files)
+        output_file.write(SOURCE_OUTRO)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -11,6 +11,8 @@ SOURCE_INTRO = """
 namespace {
 """
 SOURCE_OUTRO = """
+    std::unordered_map<std::string, EmbeddedContent> embedded = {
+%s
     };
 
 }  // namespace
@@ -49,9 +51,11 @@ def write_file_bytes(file, name, file_bytes):
     file.write('0};\n')
 
 
-def write_file_info(file, file_list):
+def create_file_info(file, file_list):
+    output = []
     for name, base, length in file_list:
-        file.write('        {"/%s", { %s, %d }},\n' % (base, name, length))
+        output.append('        {"/%s", { %s, %d }},\n' % (base, name, length))
+    return ''.join(output)
 
 
 def main():
@@ -71,9 +75,8 @@ def main():
             files.append((name, os.path.basename(file_name), len(file_bytes)))
             write_file_bytes(output_file, name, file_bytes)
 
-        output_file.write("\n    std::unordered_map<std::string, EmbeddedContent> embedded = {\n")
-        write_file_info(output_file, files)
-        output_file.write(SOURCE_OUTRO)
+        file_info = create_file_info(output_file, files)
+        output_file.write(SOURCE_OUTRO % file_info)
 
 
 if __name__ == '__main__':

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -4,14 +4,14 @@ import os, os.path, sys
 
 MAX_SLICE = 70
 
-print """
+print("""
 #include "internal/Embedded.h"
 
 #include <string>
 #include <unordered_map>
 
 namespace {
-"""
+""")
 
 files = []
 index = 1
@@ -21,19 +21,19 @@ for f in sys.argv[1:]:
     name = "fileData%d" % index
     index += 1
     files.append((name, os.path.basename(f), len(bytes)))
-    print 'const char %s[] = {' % name
+    print('const char %s[] = {' % name)
     for start in range(0, len(bytes), MAX_SLICE):
-        print '' + "".join(["'\\x%02x'," % ord(x) for x in bytes[start:start+MAX_SLICE]])
-    print '0 };'
+        print('' + "".join(["'\\x%02x'," % x for x in bytes[start:start+MAX_SLICE]]))
+    print('0 };')
 
-print """
+print("""
 std::unordered_map<std::string, EmbeddedContent> embedded = {
-"""
+""")
 
 for name, base, length in files:
-    print '{"/%s", { %s, %d }},' % (base, name, length)
+    print('{"/%s", { %s, %d }},' % (base, name, length))
 
-print """
+print("""
 };
 
 }  // namespace
@@ -45,5 +45,5 @@ const EmbeddedContent* findEmbeddedContent(const std::string& name) {
 	}
 	return &found->second;
 }
-"""
+""")
 

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -43,7 +43,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def create_file_byte(file, name, file_bytes):
+def create_file_byte(name, file_bytes):
     output = []
     output.append('    const char %s[] = {' % name)
 
@@ -53,7 +53,7 @@ def create_file_byte(file, name, file_bytes):
     return ''.join(output)
 
 
-def create_file_info(file, file_list):
+def create_file_info(file_list):
     output = []
     for name, base, length in file_list:
         output.append('        {"/%s", { %s, %d }},\n' % (base, name, length))
@@ -74,9 +74,9 @@ def main():
             name = "fileData%d" % index
             index += 1
             files.append((name, os.path.basename(file_name), len(file_bytes)))
-            file_byte_entries.append(create_file_byte(output_file, name, file_bytes))
+            file_byte_entries.append(create_file_byte(name, file_bytes))
 
-        output_file.write(SOURCE_TEMPLATE % (''.join(file_byte_entries), create_file_info(output_file, files)))
+        output_file.write(SOURCE_TEMPLATE % (''.join(file_byte_entries), create_file_info(files)))
 
 
 if __name__ == '__main__':

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -39,11 +39,11 @@ print("""
 }  // namespace
 
 const EmbeddedContent* findEmbeddedContent(const std::string& name) {
-	auto found = embedded.find(name);
-	if (found == embedded.end()) {
-		return nullptr;
-	}
-	return &found->second;
+    auto found = embedded.find(name);
+    if (found == embedded.end()) {
+        return nullptr;
+    }
+    return &found->second;
 }
 """)
 

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -63,19 +63,19 @@ def create_file_info(file_list):
 def main():
     args = parse_arguments()
 
+    files = []
+    index = 1
+    file_byte_entries = []
+
+    for file_name in args.input_file:
+        with open(file_name, 'rb') as f:
+            file_bytes = f.read()
+        name = "fileData%d" % index
+        index += 1
+        files.append((name, os.path.basename(file_name), len(file_bytes)))
+        file_byte_entries.append(create_file_byte(name, file_bytes))
+
     with open(args.output_file, 'w') as output_file:
-        files = []
-        index = 1
-        file_byte_entries = []
-
-        for file_name in args.input_file:
-            with open(file_name, 'rb') as f:
-                file_bytes = f.read()
-            name = "fileData%d" % index
-            index += 1
-            files.append((name, os.path.basename(file_name), len(file_bytes)))
-            file_byte_entries.append(create_file_byte(name, file_bytes))
-
         output_file.write(SOURCE_TEMPLATE % (''.join(file_byte_entries), create_file_info(files)))
 
 

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -39,7 +39,7 @@ print("""
 }  // namespace
 
 const EmbeddedContent* findEmbeddedContent(const std::string& name) {
-    auto found = embedded.find(name);
+    const auto found = embedded.find(name);
     if (found == embedded.end()) {
         return nullptr;
     }

--- a/scripts/gen_embedded.py
+++ b/scripts/gen_embedded.py
@@ -2,7 +2,15 @@
 
 import os, os.path, sys
 
+
 MAX_SLICE = 70
+
+def as_byte(data):
+    if sys.version_info < (3,):
+        return ord(data)
+    else:
+        return data
+
 
 print("""
 #include "internal/Embedded.h"
@@ -23,7 +31,7 @@ for f in sys.argv[1:]:
     files.append((name, os.path.basename(f), len(bytes)))
     print('const char %s[] = {' % name)
     for start in range(0, len(bytes), MAX_SLICE):
-        print('' + "".join(["'\\x%02x'," % x for x in bytes[start:start+MAX_SLICE]]))
+        print('' + "".join(["'\\x%02x'," % as_byte(x) for x in bytes[start:start+MAX_SLICE]]))
     print('0 };')
 
 print("""

--- a/src/main/web/CMakeLists.txt
+++ b/src/main/web/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SCRIPT "${PROJECT_SOURCE_DIR}/scripts/gen_embedded.py")
 
 
-set(EMBEDDED_FILES 
+set(EMBEDDED_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/_404.png
     ${CMAKE_CURRENT_SOURCE_DIR}/_error.css
     ${CMAKE_CURRENT_SOURCE_DIR}/_error.html
@@ -13,7 +13,7 @@ set(EMBEDDED_FILES
 
 
 add_custom_command(OUTPUT Embedded.cpp
-                        COMMAND ${PYTHON_BIN} ${SCRIPT} ${EMBEDDED_FILES} $<ANGLE-R> Embedded.cpp
+                        COMMAND ${PYTHON_BIN} ${SCRIPT} -o Embedded.cpp -f ${EMBEDDED_FILES}
                         COMMENT "Generating embedded content"
                         )
 add_library(embedded OBJECT Embedded.cpp)


### PR DESCRIPTION
Support for python3 (_only_). Unfortunately this breaks python2 compatibility because of this single line (`ord(x)` vs. `x`):

###### pyhon2:
```py
print '' + "".join(["'\\x%02x'," % ord(x) for x in bytes[start:start+MAX_SLICE]])
```
###### python3:
```py
print('' + "".join(["'\\x%02x'," % x for x in bytes[start:start+MAX_SLICE]])) 
```

@mattgodbolt is there any way to get this around so we can support both versions?

-----------------------------------------------------------
## Progress

- [x] Python 3 support
- [x] Python 2 support
- [x] Write to file directly
- [x] Update CMake (Python version and script usage)
- [x] Refactor `gen_embedded.py`