### PR TITLE
Update CMakeLists.txt to work on CMake 3.12

### DIFF
--- a/src/app/c/CMakeLists.txt
+++ b/src/app/c/CMakeLists.txt
@@ -14,12 +14,12 @@ add_app(streaming_test)
 
 add_custom_command(TARGET ws_test POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/src/ws_test_web $<TARGET_FILE_DIR:ws_test>/src/ws_test_web)
+        ${PROJECT_SOURCE_DIR}/src/ws_test_web $<TARGET_FILE_DIR:ws_test>/src/ws_test_web)
 
 add_custom_command(TARGET async_test POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/src/async_test_web $<TARGET_FILE_DIR:async_test>/src/async_test_web)
+        ${PROJECT_SOURCE_DIR}/src/async_test_web $<TARGET_FILE_DIR:async_test>/src/async_test_web)
 
 add_custom_command(TARGET ws_chatroom POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/src/ws_chatroom $<TARGET_FILE_DIR:ws_chatroom>/src/ws_chatroom_web)
+        ${PROJECT_SOURCE_DIR}/src/ws_chatroom_web $<TARGET_FILE_DIR:ws_chatroom>/src/ws_chatroom_web)


### PR DESCRIPTION
This fixes the following errors when trying to build with CMake 3.12:

Error copying directory from "/home/neel/git/seasocks/src/ws_chatroom" to "/home/neel/git/seasocks/src/app/c/src/ws_chatroom_web".

All of these seem to fail on the latest version of CMake.