### PR TITLE
Escaping for non-ascii characters

### DIFF
--- a/src/main/c/util/Json.cpp
+++ b/src/main/c/util/Json.cpp
@@ -34,7 +34,7 @@ void jsonToStream(std::ostream& str, const char* t) {
     for (; *t; ++t) {
         switch (*t) {
         default:
-            if (*t >= 32) {
+            if (static_cast<unsigned char>(*t) >= 32) {
                 str << *t;
             } else {
                 str << "\\u" << std::setw(4)

--- a/src/test/c/JsonTests.cpp
+++ b/src/test/c/JsonTests.cpp
@@ -50,6 +50,12 @@ TEST_CASE("shouldHandleNewLinesInStrings", "[JsonTests]") {
     CHECK(str.str() == "\"I have\\nnew\\rlines\"");
 }
 
+TEST_CASE("shouldHandleAsciiStrings", "[JsonTests]") {
+    std::stringstream str;
+    jsonToStream(str, "0123xyz!$%(/)=_-");
+    CHECK(str.str() == R"("0123xyz!$%(/)=_-")");
+}
+
 TEST_CASE("shouldHandleCrazyChars", "[JsonTests]") {
     std::stringstream str;
     jsonToStream(str, "\x01\x02\x1f");

--- a/src/test/c/JsonTests.cpp
+++ b/src/test/c/JsonTests.cpp
@@ -62,6 +62,12 @@ TEST_CASE("shouldHandleDate", "[JsonTests]") {
     CHECK(str.str() == "new Date(209001600000).toLocaleString()");
 }
 
+TEST_CASE("shouldHandleNonAsciiChars", "[JsonTests]") {
+    std::stringstream str;
+    jsonToStream(str, "§");
+    CHECK(str.str() == R"("§")");
+}
+
 struct Object {
     void jsonToStream(std::ostream &ostr) const {
         ostr << makeMap("object", true);


### PR DESCRIPTION
Implementation of the workaround for non-ascii characters (see #105).