### PR TITLE
Clang-Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+﻿---
+AccessModifierOffset: '-4'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakTemplateDeclarations: 'true'
+ColumnLimit: '0'
+FixNamespaceComments: 'false'
+IndentCaseLabels: 'true'
+IndentWidth: '4'
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+PointerAlignment: Left
+SortIncludes: 'false'
+SpaceAfterCStyleCast: 'true'
+SpaceInEmptyParentheses: 'false'
+TabWidth: '4'
+UseTab: Never
+
+...

--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,7 @@ AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: 'false'
 AllowShortLoopsOnASingleLine: 'false'
 AlwaysBreakTemplateDeclarations: 'true'
+ConstructorInitializerIndentWidth: '8'
 ColumnLimit: '0'
 FixNamespaceComments: 'false'
 IndentCaseLabels: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/src/test/suppressions.t
 include(CTest)
 include(Compiler)
 include(GNUInstallDirs)
+include(ClangFormat)
 
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.h.in internal/Config.h)

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,12 @@
+
+find_program(CLANG_FORMAT clang-format DOC "Clang Format executable")
+
+if( CLANG_FORMAT )
+    file(GLOB_RECURSE FORMAT_SRC_FILES
+            "${PROJECT_SOURCE_DIR}/src/**.h"
+            "${PROJECT_SOURCE_DIR}/src/**.cpp"
+            )
+
+    add_custom_target(clang-format COMMAND ${CLANG_FORMAT} -i ${FORMAT_SRC_FILES})
+endif()
+

--- a/src/app/c/async_test.cpp
+++ b/src/app/c/async_test.cpp
@@ -57,16 +57,18 @@ using namespace std;
 // in the cancel() method. It is assumed the lifetime of the Server object is
 // long enough for all requests to complete before it is destroyed.
 struct AsyncResponse : Response {
-    Server &_server;
-    explicit AsyncResponse(Server &server) : _server(server) {}
+    Server& _server;
+    explicit AsyncResponse(Server& server)
+            : _server(server) {
+    }
 
     // From Response:
     virtual void handle(shared_ptr<ResponseWriter> writer) override {
-        auto &server = _server;
-        thread t([&server, writer] () mutable {
+        auto& server = _server;
+        thread t([&server, writer]() mutable {
             usleep(1000000); // A long database query...
             string response = "some kind of response...beginning<br>";
-            server.execute([response, writer]{
+            server.execute([response, writer] {
                 writer->begin(ResponseCode::Ok, TransferEncoding::Chunked);
                 writer->header("Content-type", "application/html");
                 writer->payload(response.data(), response.length());
@@ -74,13 +76,13 @@ struct AsyncResponse : Response {
             response = "more data...<br>";
             for (auto i = 0; i < 5; ++i) {
                 usleep(1000000); // more data
-                server.execute([response, writer]{
+                server.execute([response, writer] {
                     writer->payload(response.data(), response.length());
                 });
             }
             response = "Done!";
             usleep(100000); // final data
-            server.execute([response, writer]{
+            server.execute([response, writer] {
                 writer->payload(response.data(), response.length());
                 writer->finish(true);
             });
@@ -96,7 +98,7 @@ struct AsyncResponse : Response {
 
 struct DataHandler : CrackedUriPageHandler {
     virtual std::shared_ptr<Response> handle(
-            const CrackedUri &/*uri*/, const Request &request) override {
+        const CrackedUri& /*uri*/, const Request& request) override {
         return make_shared<AsyncResponse>(request.server());
     }
 };

--- a/src/app/c/ph_test.cpp
+++ b/src/app/c/ph_test.cpp
@@ -37,22 +37,24 @@
 
 using namespace seasocks;
 
-class MyPageHandler: public PageHandler {
+class MyPageHandler : public PageHandler {
 public:
     virtual std::shared_ptr<Response> handle(const Request& request) override {
         if (request.verb() == Request::Verb::Post) {
             std::string content(request.content(), request.content() + request.contentLength());
             return Response::textResponse("Thanks for the post. You said: " + content);
         }
-        if (request.verb() != Request::Verb::Get) return Response::unhandled();
+        if (request.verb() != Request::Verb::Get)
+            return Response::unhandled();
         std::ostringstream ostr;
         ostr << "<html><head><title>seasocks example</title></head>"
-                "<body>Hello, " << request.credentials()->attributes["fullName"] << "! You asked for " << request.getRequestUri()
-                << " and your ip is " << request.getRemoteAddress().sin_addr.s_addr
-                << " and a random number is " << rand()
-                << "<form action=/post method=post><input type=text name=value1></input><br>"
-                << "<input type=submit value=Submit></input></form>"
-                << "</body></html>";
+                "<body>Hello, "
+             << request.credentials()->attributes["fullName"] << "! You asked for " << request.getRequestUri()
+             << " and your ip is " << request.getRemoteAddress().sin_addr.s_addr
+             << " and a random number is " << rand()
+             << "<form action=/post method=post><input type=text name=value1></input><br>"
+             << "<input type=submit value=Submit></input></form>"
+             << "</body></html>";
         return Response::htmlResponse(ostr.str());
     }
 };

--- a/src/app/c/serve.cpp
+++ b/src/app/c/serve.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "seasocks/PrintfLogger.h"
@@ -37,7 +37,7 @@ using namespace seasocks;
 namespace {
 
 const char usage[] = "Usage: %s [-p PORT] [-v] DIR\n"
-                      "   Serves files from DIR over HTTP on port PORT\n";
+                     "   Serves files from DIR over HTTP on port PORT\n";
 
 }
 
@@ -47,11 +47,15 @@ int main(int argc, char* const argv[]) {
     int opt;
     while ((opt = getopt(argc, argv, "vp:")) != -1) {
         switch (opt) {
-        case 'v': verbose = true; break;
-        case 'p': port = atoi(optarg); break;
-        default:
-            fprintf(stderr, usage, argv[0]);
-            exit(1);
+            case 'v':
+                verbose = true;
+                break;
+            case 'p':
+                port = atoi(optarg);
+                break;
+            default:
+                fprintf(stderr, usage, argv[0]);
+                exit(1);
         }
     }
     if (optind >= argc) {
@@ -60,7 +64,7 @@ int main(int argc, char* const argv[]) {
     }
 
     auto logger = std::make_shared<PrintfLogger>(
-            verbose ? Logger::Level::Debug : Logger::Level::Access);
+        verbose ? Logger::Level::Debug : Logger::Level::Access);
     Server server(logger);
     auto root = argv[optind];
     server.serve(root, port);

--- a/src/app/c/streaming_test.cpp
+++ b/src/app/c/streaming_test.cpp
@@ -45,7 +45,7 @@ size_t streamlen(std::shared_ptr<std::istream> stream) {
     return len;
 }
 
-class MyPageHandler: public PageHandler {
+class MyPageHandler : public PageHandler {
 public:
     virtual std::shared_ptr<Response> handle(const Request& request) override {
         if (request.verb() != Request::Verb::Get) {
@@ -54,10 +54,11 @@ public:
 
         auto ss = std::make_shared<std::stringstream>();
         (*ss) << "<html><head><title>seasocks example</title></head>"
-               "<body>Hello, " << request.credentials()->attributes["fullName"] << "! You asked for " << request.getRequestUri()
-               << " and your ip is " << request.getRemoteAddress().sin_addr.s_addr
-               << " and a random number is " << rand()
-               << "</body></html>";
+                 "<body>Hello, "
+              << request.credentials()->attributes["fullName"] << "! You asked for " << request.getRequestUri()
+              << " and your ip is " << request.getRemoteAddress().sin_addr.s_addr
+              << " and a random number is " << rand()
+              << "</body></html>";
 
         auto headers = SimpleResponse::Headers({
             {"Content-Type", "text/html"},
@@ -66,11 +67,11 @@ public:
         });
 
         const auto response = std::make_shared<SimpleResponse>(
-            ResponseCode::Ok,  // response code
-            ss,                // stream
-            headers,           // headers
-            true,              // keep alive
-            true               // flush instantly
+            ResponseCode::Ok, // response code
+            ss,               // stream
+            headers,          // headers
+            true,             // keep alive
+            true              // flush instantly
         );
         return response;
     }

--- a/src/app/c/ws_chatroom.cpp
+++ b/src/app/c/ws_chatroom.cpp
@@ -41,31 +41,30 @@ using namespace seasocks;
 namespace {
 
 struct Handler : WebSocket::Handler {
-    set<WebSocket *> _cons;
+    set<WebSocket*> _cons;
 
-    void onConnect(WebSocket *con) override {
+    void onConnect(WebSocket* con) override {
         _cons.insert(con);
         send(con->credentials()->username + " has joined");
     }
-    void onDisconnect(WebSocket *con) override {
+    void onDisconnect(WebSocket* con) override {
         _cons.erase(con);
         send(con->credentials()->username + " has left");
     }
 
-    void onData(WebSocket *con, const char *data) override
-    {
+    void onData(WebSocket* con, const char* data) override {
         send(con->credentials()->username + ": " + data);
     }
 
     void send(const string& msg) {
-        for (auto *con : _cons) {
+        for (auto* con : _cons) {
             con->send(msg);
         }
     }
 };
 
 struct MyAuthHandler : PageHandler {
-    shared_ptr<Response> handle(const Request &request) override {
+    shared_ptr<Response> handle(const Request& request) override {
         // Here one would handle one's authentication system, for example;
         // * check to see if the user has a trusted cookie: if so, accept it.
         // * if not, redirect to a login handler page, and await a redirection
@@ -74,7 +73,7 @@ struct MyAuthHandler : PageHandler {
         // For this example, we set the user's authentication information purely
         // from their connection.
         request.credentials()->username = formatAddress(request.getRemoteAddress());
-        return Response::unhandled();  // cause next handler to run
+        return Response::unhandled(); // cause next handler to run
     }
 };
 

--- a/src/app/c/ws_echo.cpp
+++ b/src/app/c/ws_echo.cpp
@@ -39,7 +39,7 @@
 
 using namespace seasocks;
 
-class EchoHandler: public WebSocket::Handler {
+class EchoHandler : public WebSocket::Handler {
 public:
     virtual void onConnect(WebSocket* /*connection*/) override {
     }

--- a/src/app/c/ws_test.cpp
+++ b/src/app/c/ws_test.cpp
@@ -45,9 +45,10 @@
 using namespace seasocks;
 using namespace std;
 
-class MyHandler: public WebSocket::Handler {
+class MyHandler : public WebSocket::Handler {
 public:
-    explicit MyHandler(Server* server) : _server(server), _currentValue(0) {
+    explicit MyHandler(Server* server)
+            : _server(server), _currentValue(0) {
         setValue(1);
     }
 
@@ -55,8 +56,8 @@ public:
         _connections.insert(connection);
         connection->send(_currentSetValue.c_str());
         cout << "Connected: " << connection->getRequestUri()
-                << " : " << formatAddress(connection->getRemoteAddress())
-                << endl;
+             << " : " << formatAddress(connection->getRemoteAddress())
+             << endl;
         cout << "Credentials: " << *(connection->credentials()) << endl;
     }
 
@@ -84,8 +85,8 @@ public:
     virtual void onDisconnect(WebSocket* connection) override {
         _connections.erase(connection);
         cout << "Disconnected: " << connection->getRequestUri()
-                << " : " << formatAddress(connection->getRemoteAddress())
-                << endl;
+             << " : " << formatAddress(connection->getRemoteAddress())
+             << endl;
     }
 
 private:

--- a/src/app/c/ws_test_poll.cpp
+++ b/src/app/c/ws_test_poll.cpp
@@ -51,9 +51,10 @@
 using namespace seasocks;
 using namespace std;
 
-class MyHandler: public WebSocket::Handler {
+class MyHandler : public WebSocket::Handler {
 public:
-    explicit MyHandler(Server* server) : _server(server), _currentValue(0) {
+    explicit MyHandler(Server* server)
+            : _server(server), _currentValue(0) {
         setValue(1);
     }
 
@@ -61,8 +62,8 @@ public:
         _connections.insert(connection);
         connection->send(_currentSetValue.c_str());
         cout << "Connected: " << connection->getRequestUri()
-                << " : " << formatAddress(connection->getRemoteAddress())
-                << endl;
+             << " : " << formatAddress(connection->getRemoteAddress())
+             << endl;
         cout << "Credentials: " << *(connection->credentials()) << endl;
     }
 
@@ -90,8 +91,8 @@ public:
     virtual void onDisconnect(WebSocket* connection) override {
         _connections.erase(connection);
         cout << "Disconnected: " << connection->getRequestUri()
-                << " : " << formatAddress(connection->getRemoteAddress())
-                << endl;
+             << " : " << formatAddress(connection->getRemoteAddress())
+             << endl;
     }
 
 private:
@@ -119,11 +120,11 @@ int main(int /*argc*/, const char* /*argv*/[]) {
         return 1;
     }
     int myEpoll = epoll_create(10);
-    epoll_event wakeSeasocks = { EPOLLIN|EPOLLOUT|EPOLLERR, { &server } };
+    epoll_event wakeSeasocks = {EPOLLIN | EPOLLOUT | EPOLLERR, {&server}};
     epoll_ctl(myEpoll, EPOLL_CTL_ADD, server.fd(), &wakeSeasocks);
 
     // Also poll stdin
-    epoll_event wakeStdin = { EPOLLIN, { nullptr } };
+    epoll_event wakeStdin = {EPOLLIN, {nullptr}};
     epoll_ctl(myEpoll, EPOLL_CTL_ADD, STDIN_FILENO, &wakeStdin);
     auto prevFlags = fcntl(STDIN_FILENO, F_GETFL, 0);
     fcntl(STDIN_FILENO, F_SETFL, prevFlags | O_NONBLOCK);
@@ -140,8 +141,10 @@ int main(int /*argc*/, const char* /*argv*/[]) {
         for (auto i = 0; i < res; ++i) {
             if (events[i].data.ptr == &server) {
                 auto seasocksResult = server.poll(0);
-                if (seasocksResult == Server::PollResult::Terminated) return 0;
-                if (seasocksResult == Server::PollResult::Error) return 1;
+                if (seasocksResult == Server::PollResult::Terminated)
+                    return 0;
+                if (seasocksResult == Server::PollResult::Error)
+                    return 1;
             } else if (events[i].data.ptr == nullptr) {
                 // Echo stdin to stdout to show we can read from that too.
                 for (;;) {

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -86,40 +86,40 @@ char* extractLine(uint8_t*& first, uint8_t* last, char** colon = nullptr) {
             ptr[0] = 0;
             uint8_t* result = first;
             first = ptr + 2;
-            return reinterpret_cast<char*> (result);
+            return reinterpret_cast<char*>(result);
         }
         if (colon && ptr[0] == ':' && *colon == nullptr) {
-            *colon = reinterpret_cast<char*> (ptr);
+            *colon = reinterpret_cast<char*>(ptr);
         }
     }
     return nullptr;
 }
 
 const std::unordered_map<std::string, std::string> contentTypes = {
-    { "txt", "text/plain" },
-    { "css", "text/css" },
-    { "csv", "text/csv" },
-    { "htm", "text/html" },
-    { "html", "text/html" },
-    { "xml", "text/xml" },
-    { "js", "text/javascript" }, // Technically it should be application/javascript (RFC 4329), but IE8 struggles with that
-    { "xhtml", "application/xhtml+xml" },
-    { "json", "application/json" },
-    { "pdf", "application/pdf" },
-    { "zip", "application/zip" },
-    { "tar", "application/x-tar" },
-    { "gif", "image/gif" },
-    { "jpeg", "image/jpeg" },
-    { "jpg", "image/jpeg" },
-    { "tiff", "image/tiff" },
-    { "tif", "image/tiff" },
-    { "png", "image/png" },
-    { "svg", "image/svg+xml" },
-    { "ico", "image/x-icon" },
-    { "swf", "application/x-shockwave-flash" },
-    { "mp3", "audio/mpeg" },
-    { "wav", "audio/x-wav" },
-    { "ttf", "font/ttf" },
+    {"txt", "text/plain"},
+    {"css", "text/css"},
+    {"csv", "text/csv"},
+    {"htm", "text/html"},
+    {"html", "text/html"},
+    {"xml", "text/xml"},
+    {"js", "text/javascript"}, // Technically it should be application/javascript (RFC 4329), but IE8 struggles with that
+    {"xhtml", "application/xhtml+xml"},
+    {"json", "application/json"},
+    {"pdf", "application/pdf"},
+    {"zip", "application/zip"},
+    {"tar", "application/x-tar"},
+    {"gif", "image/gif"},
+    {"jpeg", "image/jpeg"},
+    {"jpg", "image/jpeg"},
+    {"tiff", "image/tiff"},
+    {"tif", "image/tiff"},
+    {"png", "image/png"},
+    {"svg", "image/svg+xml"},
+    {"ico", "image/x-icon"},
+    {"swf", "application/x-shockwave-flash"},
+    {"mp3", "audio/mpeg"},
+    {"wav", "audio/x-wav"},
+    {"ttf", "font/ttf"},
 };
 
 std::string getExt(const std::string& path) {
@@ -157,16 +157,18 @@ constexpr size_t MaxHeadersSize = 64 * 1024;
 class PrefixWrapper : public seasocks::Logger {
     std::string _prefix;
     std::shared_ptr<Logger> _logger;
+
 public:
     PrefixWrapper(const std::string& prefix, std::shared_ptr<Logger> logger)
-    : _prefix(prefix), _logger(logger) {}
+            : _prefix(prefix), _logger(logger) {
+    }
 
     virtual void log(Level level, const char* message) override {
         _logger->log(level, (_prefix + message).c_str());
     }
 };
 
-bool hasConnectionType(const std::string &connection, const std::string &type) {
+bool hasConnectionType(const std::string& connection, const std::string& type) {
     for (auto conType : seasocks::split(connection, ',')) {
         while (!conType.empty() && isspace(conType[0]))
             conType = conType.substr(1);
@@ -176,30 +178,39 @@ bool hasConnectionType(const std::string &connection, const std::string &type) {
     return false;
 }
 
-}  // namespace
+} // namespace
 
 namespace seasocks {
 
 struct Connection::Writer : ResponseWriter {
-    Connection *_connection;
-    explicit Writer(Connection &connection) : _connection(&connection) {}
+    Connection* _connection;
+    explicit Writer(Connection& connection)
+            : _connection(&connection) {
+    }
 
-    void detach() { _connection = nullptr; }
+    void detach() {
+        _connection = nullptr;
+    }
 
     void begin(ResponseCode responseCode, TransferEncoding encoding) override {
-        if (_connection) _connection->begin(responseCode, encoding);
+        if (_connection)
+            _connection->begin(responseCode, encoding);
     }
-    void header(const std::string &header, const std::string &value) override {
-        if (_connection) _connection->header(header, value);
+    void header(const std::string& header, const std::string& value) override {
+        if (_connection)
+            _connection->header(header, value);
     }
-    void payload(const void *data, size_t size, bool flush) override {
-        if (_connection) _connection->payload(data, size, flush);
+    void payload(const void* data, size_t size, bool flush) override {
+        if (_connection)
+            _connection->payload(data, size, flush);
     }
     void finish(bool keepConnectionOpen) override {
-        if (_connection) _connection->finish(keepConnectionOpen);
+        if (_connection)
+            _connection->finish(keepConnectionOpen);
     }
-    void error(ResponseCode responseCode, const std::string &payload) override {
-        if (_connection) _connection->error(responseCode, payload);
+    void error(ResponseCode responseCode, const std::string& payload) override {
+        if (_connection)
+            _connection->error(responseCode, payload);
     }
 
     bool isActive() const override {
@@ -208,25 +219,25 @@ struct Connection::Writer : ResponseWriter {
 };
 
 Connection::Connection(
-        std::shared_ptr<Logger> logger,
-        ServerImpl& server,
-        int fd,
-        const sockaddr_in& address)
-    : _logger(std::make_shared<PrefixWrapper>(formatAddress(address) + " : ", logger)),
-      _server(server),
-      _fd(fd),
-      _shutdown(false),
-      _hadSendError(false),
-      _closeOnEmpty(false),
-      _registeredForWriteEvents(false),
-      _address(address),
-      _bytesSent(0),
-      _bytesReceived(0),
-      _shutdownByUser(false),
-      _transferEncoding(TransferEncoding::Raw),
-      _chunk(0u),
-      _writer(std::make_shared<Writer>(*this)),
-      _state(State::READING_HEADERS) {
+    std::shared_ptr<Logger> logger,
+    ServerImpl& server,
+    int fd,
+    const sockaddr_in& address)
+        : _logger(std::make_shared<PrefixWrapper>(formatAddress(address) + " : ", logger)),
+          _server(server),
+          _fd(fd),
+          _shutdown(false),
+          _hadSendError(false),
+          _closeOnEmpty(false),
+          _registeredForWriteEvents(false),
+          _address(address),
+          _bytesSent(0),
+          _bytesReceived(0),
+          _shutdownByUser(false),
+          _transferEncoding(TransferEncoding::Raw),
+          _chunk(0u),
+          _writer(std::make_shared<Writer>(*this)),
+          _state(State::READING_HEADERS) {
 }
 
 Connection::~Connection() {
@@ -319,7 +330,7 @@ bool Connection::write(const void* data, size_t size, bool flushIt) {
         size_t newBufferSize = endOfBuffer + bytesToBuffer;
         if (newBufferSize >= _server.clientBufferSize()) {
             LS_WARNING(_logger, "Closing connection: buffer size too large ("
-                    << newBufferSize << " >= " << _server.clientBufferSize() << ")");
+                                    << newBufferSize << " >= " << _server.clientBufferSize() << ")");
             closeInternal();
             return false;
         }
@@ -333,8 +344,9 @@ bool Connection::write(const void* data, size_t size, bool flushIt) {
 }
 
 bool Connection::bufferLine(const char* line) {
-    static const char crlf[] = { '\r', '\n' };
-    if (!write(line, strlen(line), false)) return false;
+    static const char crlf[] = {'\r', '\n'};
+    if (!write(line, strlen(line), false))
+        return false;
     return write(crlf, 2, false);
 }
 
@@ -404,28 +416,28 @@ bool Connection::closed() const {
 
 void Connection::handleNewData() {
     switch (_state) {
-    case State::READING_HEADERS:
-        handleHeaders();
-        break;
+        case State::READING_HEADERS:
+            handleHeaders();
+            break;
         case State::READING_WEBSOCKET_KEY3:
-        handleWebSocketKey3();
-        break;
-    case State::HANDLING_HIXIE_WEBSOCKET:
-        handleHixieWebSocket();
-        break;
-    case State::HANDLING_HYBI_WEBSOCKET:
-        handleHybiWebSocket();
-        break;
-    case State::BUFFERING_POST_DATA:
-        handleBufferingPostData();
-        break;
-    case State::AWAITING_RESPONSE_BEGIN:
-    case State::SENDING_RESPONSE_BODY:
-    case State::SENDING_RESPONSE_HEADERS:
-        break;
-    default:
-        assert(false);
-        break;
+            handleWebSocketKey3();
+            break;
+        case State::HANDLING_HIXIE_WEBSOCKET:
+            handleHixieWebSocket();
+            break;
+        case State::HANDLING_HYBI_WEBSOCKET:
+            handleHybiWebSocket();
+            break;
+        case State::BUFFERING_POST_DATA:
+            handleBufferingPostData();
+            break;
+        case State::AWAITING_RESPONSE_BEGIN:
+        case State::SENDING_RESPONSE_BODY:
+        case State::SENDING_RESPONSE_HEADERS:
+            break;
+        default:
+            assert(false);
+            break;
     }
 }
 
@@ -435,9 +447,9 @@ void Connection::handleHeaders() {
     }
     for (size_t i = 0; i <= _inBuf.size() - 4; ++i) {
         if (_inBuf[i] == '\r' &&
-            _inBuf[i+1] == '\n' &&
-            _inBuf[i+2] == '\r' &&
-            _inBuf[i+3] == '\n') {
+            _inBuf[i + 1] == '\n' &&
+            _inBuf[i + 2] == '\r' &&
+            _inBuf[i + 3] == '\n') {
             if (!processHeaders(&_inBuf[0], &_inBuf[i + 2])) {
                 closeInternal();
                 return;
@@ -486,7 +498,7 @@ void Connection::handleWebSocketKey3() {
     bufferLine("Connection: Upgrade");
     bool allowCrossOrigin = _server.isCrossOriginAllowed(_request->getRequestUri());
     if (_request->hasHeader("Origin") && allowCrossOrigin) {
-        bufferLine("Sec-WebSocket-Origin: " +  _request->getHeader("Origin"));
+        bufferLine("Sec-WebSocket-Origin: " + _request->getHeader("Origin"));
     }
     if (_request->hasHeader("Host")) {
         auto host = _request->getHeader("Host");
@@ -509,12 +521,13 @@ void Connection::handleWebSocketKey3() {
 
 void Connection::pickProtocol() {
     static std::string protocolHeader = "Sec-WebSocket-Protocol";
-    if (!_request->hasHeader(protocolHeader) || !_webSocketHandler) return;
+    if (!_request->hasHeader(protocolHeader) || !_webSocketHandler)
+        return;
     // Ideally we need o support this header being set multiple times...but the headers don't support that.
     auto protocols = split(_request->getHeader(protocolHeader), ',');
     LS_DEBUG(_logger, "Requested protocols:");
     std::transform(protocols.begin(), protocols.end(), protocols.begin(), trimWhitespace);
-    for (auto &&p : protocols) {
+    for (auto&& p : protocols) {
         LS_DEBUG(_logger, "  " + p);
     }
     auto choice = _webSocketHandler->chooseProtocol(protocols);
@@ -544,8 +557,10 @@ void Connection::send(const char* webSocketResponse) {
     auto messageLength = strlen(webSocketResponse);
     if (_state == State::HANDLING_HIXIE_WEBSOCKET) {
         uint8_t zero = 0;
-        if (!write(&zero, 1, false)) return;
-        if (!write(webSocketResponse, messageLength, false)) return;
+        if (!write(&zero, 1, false))
+            return;
+        if (!write(webSocketResponse, messageLength, false))
+            return;
         uint8_t effeff = 0xff;
         write(&effeff, 1, true);
         return;
@@ -572,8 +587,10 @@ void Connection::send(const uint8_t* data, size_t length) {
 
 void Connection::sendHybi(uint8_t opcode, const uint8_t* webSocketResponse, size_t messageLength) {
     uint8_t firstByte = 0x80 | opcode;
-    if (_perMessageDeflate) firstByte |= 0x40;
-    if (!write(&firstByte, 1, false)) return;
+    if (_perMessageDeflate)
+        firstByte |= 0x40;
+    if (!write(&firstByte, 1, false))
+        return;
 
     if (_perMessageDeflate) {
         std::vector<uint8_t> compressed;
@@ -590,17 +607,22 @@ void Connection::sendHybi(uint8_t opcode, const uint8_t* webSocketResponse, size
 void Connection::sendHybiData(const uint8_t* webSocketResponse, size_t messageLength) {
     if (messageLength < 126) {
         uint8_t nextByte = messageLength; // No MASK bit set.
-        if (!write(&nextByte, 1, false)) return;
+        if (!write(&nextByte, 1, false))
+            return;
     } else if (messageLength < 65536) {
         uint8_t nextByte = 126; // No MASK bit set.
-        if (!write(&nextByte, 1, false)) return;
+        if (!write(&nextByte, 1, false))
+            return;
         auto lengthBytes = htons(messageLength);
-        if (!write(&lengthBytes, 2, false)) return;
+        if (!write(&lengthBytes, 2, false))
+            return;
     } else {
         uint8_t nextByte = 127; // No MASK bit set.
-        if (!write(&nextByte, 1, false)) return;
+        if (!write(&nextByte, 1, false))
+            return;
         uint64_t lengthBytes = __bswap_64(messageLength);
-        if (!write(&lengthBytes, 8, false)) return;
+        if (!write(&lengthBytes, 8, false))
+            return;
     }
     write(webSocketResponse, messageLength, true);
 }
@@ -617,7 +639,7 @@ void Connection::handleHixieWebSocket() {
     size_t messageStart = 0;
     while (messageStart < _inBuf.size()) {
         if (_inBuf[messageStart] != 0) {
-            LS_WARNING(_logger, "Error in WebSocket input stream (got " << (int)_inBuf[messageStart] << ")");
+            LS_WARNING(_logger, "Error in WebSocket input stream (got " << (int) _inBuf[messageStart] << ")");
             closeInternal();
             return;
         }
@@ -686,35 +708,35 @@ void Connection::handleHybiWebSocket() {
 
 
         switch (messageState) {
-        default:
-            closeInternal();
-            LS_WARNING(_logger, "Unknown HybiPacketDecoder state");
-            return;
-        case HybiPacketDecoder::MessageState::Error:
-            closeInternal();
-            return;
-        case HybiPacketDecoder::MessageState::TextMessage:
-            decodedMessage.push_back(0);  // avoids a copy
-            handleWebSocketTextMessage(reinterpret_cast<const char*>(&decodedMessage[0]));
-            break;
-        case HybiPacketDecoder::MessageState::BinaryMessage:
-            handleWebSocketBinaryMessage(decodedMessage);
-            break;
-        case HybiPacketDecoder::MessageState::Ping:
-            sendHybi(static_cast<uint8_t>(HybiPacketDecoder::Opcode::Pong),
-                     &decodedMessage[0], decodedMessage.size());
-            break;
-        case HybiPacketDecoder::MessageState::Pong:
-            // Pongs can be sent unsolicited (MSIE and Edge do this)
-            // The spec says to ignore them.
-            break;
-        case HybiPacketDecoder::MessageState::NoMessage:
-            done = true;
-            break;
-        case HybiPacketDecoder::MessageState::Close:
-            LS_DEBUG(_logger, "Received WebSocket close");
-            closeInternal();
-            return;
+            default:
+                closeInternal();
+                LS_WARNING(_logger, "Unknown HybiPacketDecoder state");
+                return;
+            case HybiPacketDecoder::MessageState::Error:
+                closeInternal();
+                return;
+            case HybiPacketDecoder::MessageState::TextMessage:
+                decodedMessage.push_back(0); // avoids a copy
+                handleWebSocketTextMessage(reinterpret_cast<const char*>(&decodedMessage[0]));
+                break;
+            case HybiPacketDecoder::MessageState::BinaryMessage:
+                handleWebSocketBinaryMessage(decodedMessage);
+                break;
+            case HybiPacketDecoder::MessageState::Ping:
+                sendHybi(static_cast<uint8_t>(HybiPacketDecoder::Opcode::Pong),
+                         &decodedMessage[0], decodedMessage.size());
+                break;
+            case HybiPacketDecoder::MessageState::Pong:
+                // Pongs can be sent unsolicited (MSIE and Edge do this)
+                // The spec says to ignore them.
+                break;
+            case HybiPacketDecoder::MessageState::NoMessage:
+                done = true;
+                break;
+            case HybiPacketDecoder::MessageState::Close:
+                LS_DEBUG(_logger, "Received WebSocket close");
+                closeInternal();
+                return;
         }
     }
     if (decoder.numBytesDecoded() != 0) {
@@ -755,9 +777,9 @@ bool Connection::sendError(ResponseCode errorCode, const std::string& body) {
     } else {
         std::stringstream documentStr;
         documentStr << "<html><head><title>" << errorNumber << " - " << message << "</title></head>"
-                << "<body><h1>" << errorNumber << " - " << message << "</h1>"
-                << "<div>" << body << "</div><hr/><div><i>Powered by "
-                   "<a href=\"https://github.com/mattgodbolt/seasocks\">Seasocks</a></i></div></body></html>";
+                    << "<body><h1>" << errorNumber << " - " << message << "</h1>"
+                    << "<div>" << body << "</div><hr/><div><i>Powered by "
+                                          "<a href=\"https://github.com/mattgodbolt/seasocks\">Seasocks</a></i></div></body></html>";
         document = documentStr.str();
     }
     bufferLine("Content-Length: " + toString(document.length()));
@@ -844,9 +866,7 @@ bool Connection::processHeaders(uint8_t* first, uint8_t* last) {
         headers.emplace(key, value);
     }
 
-    if (headers.count("Connection") && headers.count("Upgrade")
-            && hasConnectionType(headers["Connection"], "Upgrade")
-            && caseInsensitiveSame(headers["Upgrade"], "websocket")) {
+    if (headers.count("Connection") && headers.count("Upgrade") && hasConnectionType(headers["Connection"], "Upgrade") && caseInsensitiveSame(headers["Upgrade"], "websocket")) {
         LS_INFO(_logger, "Websocket request for " << requestUri << "'");
         if (verb != Request::Verb::Get) {
             return sendBadRequest("Non-GET WebSocket request");
@@ -864,9 +884,9 @@ bool Connection::processHeaders(uint8_t* first, uint8_t* last) {
     }
 
     _request = std::make_unique<PageRequest>(_address, requestUri, _server.server(),
-                                   verb, std::move(headers));
+                                             verb, std::move(headers));
 
-    const EmbeddedContent *embedded = findEmbeddedContent(requestUri);
+    const EmbeddedContent* embedded = findEmbeddedContent(requestUri);
     if (verb == Request::Verb::Get && embedded) {
         // MRG: one day, this could be a request handler.
         return sendData(getContentType(requestUri), embedded->data, embedded->length);
@@ -927,7 +947,7 @@ bool Connection::sendResponse(std::shared_ptr<Response> response) {
     return true;
 }
 
-void Connection::error(ResponseCode responseCode, const std::string &payload) {
+void Connection::error(ResponseCode responseCode, const std::string& payload) {
     _server.checkThread();
     if (_state != State::AWAITING_RESPONSE_BEGIN) {
         LS_ERROR(_logger, "error() called when in wrong state");
@@ -958,7 +978,7 @@ void Connection::begin(ResponseCode responseCode, TransferEncoding encoding) {
     }
 }
 
-void Connection::header(const std::string &header, const std::string &value) {
+void Connection::header(const std::string& header, const std::string& value) {
     _server.checkThread();
     if (_state != State::SENDING_RESPONSE_HEADERS) {
         LS_ERROR(_logger, "header() called when in wrong state");
@@ -966,7 +986,7 @@ void Connection::header(const std::string &header, const std::string &value) {
     }
     bufferLine(header + ": " + value);
 }
-void Connection::payload(const void *data, size_t size, bool flush) {
+void Connection::payload(const void* data, size_t size, bool flush) {
     _server.checkThread();
     if (_state == State::SENDING_RESPONSE_HEADERS) {
         bufferLine("");
@@ -983,7 +1003,8 @@ void Connection::payload(const void *data, size_t size, bool flush) {
 
 void Connection::writeChunkHeader(size_t size) {
     std::ostringstream lengthStr;
-    if (_chunk) lengthStr << "\r\n";
+    if (_chunk)
+        lengthStr << "\r\n";
     lengthStr << std::hex << size << "\r\n";
     auto length = lengthStr.str();
     _chunk++;
@@ -1014,8 +1035,8 @@ void Connection::finish(bool keepConnectionOpen) {
 }
 
 bool Connection::handleHybiHandshake(
-        int webSocketVersion,
-        const std::string& webSocketKey) {
+    int webSocketVersion,
+    const std::string& webSocketKey) {
     if (webSocketVersion != 8 && webSocketVersion != 13) {
         return sendBadRequest("Invalid websocket version");
     }
@@ -1027,7 +1048,8 @@ bool Connection::handleHybiHandshake(
     bufferLine("Upgrade: websocket");
     bufferLine("Connection: Upgrade");
     bufferLine("Sec-WebSocket-Accept: " + getAcceptKey(webSocketKey));
-    if (_perMessageDeflate) bufferLine("Sec-WebSocket-Extensions: permessage-deflate");
+    if (_perMessageDeflate)
+        bufferLine("Sec-WebSocket-Extensions: permessage-deflate");
     pickProtocol();
     bufferLine("");
     flush();
@@ -1040,7 +1062,7 @@ bool Connection::handleHybiHandshake(
 }
 
 void Connection::parsePerMessageDeflateHeader(const std::string& header) {
-    for (auto &extField : seasocks::split(header, ';')) {
+    for (auto& extField : seasocks::split(header, ';')) {
         while (!extField.empty() && isspace(extField[0]))
             extField = extField.substr(1);
 
@@ -1065,7 +1087,7 @@ bool Connection::parseRange(const std::string& rangeStr, Range& range) const {
         return true;
     } else {
         range.start = atoi(rangeStr.substr(0, minusPos).c_str());
-        if (minusPos == rangeStr.size()-1) {
+        if (minusPos == rangeStr.size() - 1) {
             range.end = std::numeric_limits<long>::max();
         } else {
             range.end = atoi(rangeStr.substr(minusPos + 1).c_str());
@@ -1082,7 +1104,7 @@ bool Connection::parseRanges(const std::string& range, std::list<Range>& ranges)
         return false;
     }
     auto rangesText = split(range.substr(expectedPrefix.length()), ',');
-    for (auto & it : rangesText) {
+    for (auto& it : rangesText) {
         Range r;
         if (!parseRange(it, r)) {
             return false;
@@ -1099,7 +1121,7 @@ std::list<Connection::Range> Connection::processRangesForStaticData(const std::l
         // Easy case: a non-range request.
         bufferResponseAndCommonHeaders(ResponseCode::Ok);
         bufferLine("Content-Length: " + toString(fileSize));
-        return { Range { 0, fileSize - 1 } };
+        return {Range{0, fileSize - 1}};
     }
 
     // Partial content request.
@@ -1223,7 +1245,7 @@ void Connection::setLinger() {
         return;
     }
     const int secondsToLinger = 1;
-    struct linger linger = { true, secondsToLinger };
+    struct linger linger = {true, secondsToLinger};
     if (::setsockopt(_fd, SOL_SOCKET, SO_LINGER, &linger, sizeof(linger)) == -1) {
         LS_INFO(_logger, "Unable to set linger on socket");
     }
@@ -1242,8 +1264,8 @@ const std::string& Connection::getRequestUri() const {
     return _request ? _request->getRequestUri() : empty;
 }
 
-Server &Connection::server() const {
+Server& Connection::server() const {
     return _server.server();
 }
 
-}  // seasocks
+} // seasocks

--- a/src/main/c/HybiAccept.cpp
+++ b/src/main/c/HybiAccept.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "internal/Base64.h"
@@ -32,7 +32,9 @@
 
 namespace seasocks {
 
-namespace { const char *magicString = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; }
+namespace {
+const char* magicString = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+}
 
 std::string getAcceptKey(const std::string& challenge) {
     auto fullString = challenge + magicString;
@@ -40,7 +42,7 @@ std::string getAcceptKey(const std::string& challenge) {
     hasher.Input(fullString.c_str(), fullString.size());
     unsigned hash[5];
     hasher.Result(hash);
-    for (unsigned int & i : hash) {
+    for (unsigned int& i : hash) {
         i = htonl(i);
     }
     return base64Encode(hash, sizeof(hash));

--- a/src/main/c/HybiPacketDecoder.cpp
+++ b/src/main/c/HybiPacketDecoder.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "internal/HybiPacketDecoder.h"
@@ -33,14 +33,14 @@
 namespace seasocks {
 
 HybiPacketDecoder::HybiPacketDecoder(Logger& logger,
-                                     const std::vector<uint8_t>& buffer) :
-    _logger(logger),
-    _buffer(buffer),
-    _messageStart(0) {
+                                     const std::vector<uint8_t>& buffer)
+        : _logger(logger),
+          _buffer(buffer),
+          _messageStart(0) {
 }
 
 HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
-        std::vector<uint8_t>& messageOut, bool& deflateNeeded) {
+    std::vector<uint8_t>& messageOut, bool& deflateNeeded) {
     if (_messageStart + 1 >= _buffer.size()) {
         return MessageState::NoMessage;
     }
@@ -51,7 +51,7 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
         return MessageState::Error;
     }
 
-    auto reservedBits = _buffer[_messageStart] & (7<<4);
+    auto reservedBits = _buffer[_messageStart] & (7 << 4);
     if ((reservedBits & 0x30) != 0) {
         LS_WARNING(&_logger, "Received hybi frame with reserved bits set - error");
         return MessageState::Error;
@@ -64,13 +64,17 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
     auto maskBit = _buffer[_messageStart + 1] & 0x80;
     auto ptr = _messageStart + 2;
     if (payloadLength == 126) {
-        if (_buffer.size() < 4) { return MessageState::NoMessage; }
+        if (_buffer.size() < 4) {
+            return MessageState::NoMessage;
+        }
         uint16_t raw_length;
         memcpy(&raw_length, &_buffer[ptr], sizeof(raw_length));
         payloadLength = htons(raw_length);
         ptr += 2;
     } else if (payloadLength == 127) {
-        if (_buffer.size() < 10) { return MessageState::NoMessage; }
+        if (_buffer.size() < 10) {
+            return MessageState::NoMessage;
+        }
         uint64_t raw_length;
         memcpy(&raw_length, &_buffer[ptr], sizeof(raw_length));
         payloadLength = __bswap_64(raw_length);
@@ -79,14 +83,18 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
     uint32_t mask = 0;
     if (maskBit) {
         // MASK is set.
-        if (_buffer.size() < ptr + 4) { return MessageState::NoMessage; }
+        if (_buffer.size() < ptr + 4) {
+            return MessageState::NoMessage;
+        }
         uint32_t raw_length;
         memcpy(&raw_length, &_buffer[ptr], sizeof(raw_length));
         mask = htonl(raw_length);
         ptr += 4;
     }
     auto bytesLeftInBuffer = _buffer.size() - ptr;
-    if (payloadLength > bytesLeftInBuffer) { return MessageState::NoMessage; }
+    if (payloadLength > bytesLeftInBuffer) {
+        return MessageState::NoMessage;
+    }
 
     messageOut.clear();
     messageOut.reserve(payloadLength);
@@ -96,20 +104,20 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
     }
     _messageStart = ptr;
     switch (opcode) {
-    default:
-        LS_WARNING(&_logger, "Received hybi frame with unknown opcode "
-                             << static_cast<int>(opcode));
-        return MessageState::Error;
-    case Opcode::Text:
-        return MessageState::TextMessage;
-    case Opcode::Binary:
-        return MessageState::BinaryMessage;
-    case Opcode::Ping:
-        return MessageState::Ping;
-    case Opcode::Pong:
-        return MessageState::Pong;
-    case Opcode::Close:
-        return MessageState::Close;
+        default:
+            LS_WARNING(&_logger, "Received hybi frame with unknown opcode "
+                                     << static_cast<int>(opcode));
+            return MessageState::Error;
+        case Opcode::Text:
+            return MessageState::TextMessage;
+        case Opcode::Binary:
+            return MessageState::BinaryMessage;
+        case Opcode::Ping:
+            return MessageState::Ping;
+        case Opcode::Pong:
+            return MessageState::Pong;
+        case Opcode::Close:
+            return MessageState::Close;
     }
 }
 

--- a/src/main/c/Logger.cpp
+++ b/src/main/c/Logger.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "internal/Debug.h"
@@ -34,10 +34,10 @@ namespace seasocks {
 
 constexpr int MAX_MESSAGE_LENGTH = 1024;
 
-#define PRINT_TO_MESSAGEBUF() \
-    char messageBuf[MAX_MESSAGE_LENGTH]; \
-    va_list args; \
-    va_start(args, message); \
+#define PRINT_TO_MESSAGEBUF()                                 \
+    char messageBuf[MAX_MESSAGE_LENGTH];                      \
+    va_list args;                                             \
+    va_start(args, message);                                  \
     vsnprintf(messageBuf, MAX_MESSAGE_LENGTH, message, args); \
     va_end(args)
 
@@ -46,7 +46,7 @@ void Logger::debug(const char* message, ...) {
     PRINT_TO_MESSAGEBUF();
     log(Level::Debug, messageBuf);
 #else
-    (void)message;
+    (void) message;
 #endif
 }
 
@@ -75,4 +75,4 @@ void Logger::severe(const char* message, ...) {
     log(Level::Severe, messageBuf);
 }
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/PageRequest.cpp
+++ b/src/main/c/PageRequest.cpp
@@ -31,22 +31,23 @@
 namespace seasocks {
 
 PageRequest::PageRequest(
-        const sockaddr_in& remoteAddress,
-        const std::string& requestUri,
-        Server &server,
-        Verb verb,
-        HeaderMap&& headers) :
-            _credentials(std::make_shared<Credentials>()),
-            _remoteAddress(remoteAddress),
-            _requestUri(requestUri),
-            _server(server),
-            _verb(verb),
-            _headers(std::move(headers)),
-            _contentLength(getUintHeader("Content-Length")) {
+    const sockaddr_in& remoteAddress,
+    const std::string& requestUri,
+    Server& server,
+    Verb verb,
+    HeaderMap&& headers)
+        : _credentials(std::make_shared<Credentials>()),
+          _remoteAddress(remoteAddress),
+          _requestUri(requestUri),
+          _server(server),
+          _verb(verb),
+          _headers(std::move(headers)),
+          _contentLength(getUintHeader("Content-Length")) {
 }
 
 bool PageRequest::consumeContent(std::vector<uint8_t>& buffer) {
-    if (buffer.size() < _contentLength) return false;
+    if (buffer.size() < _contentLength)
+        return false;
     if (buffer.size() == _contentLength) {
         _content.swap(buffer);
     } else {
@@ -56,12 +57,14 @@ bool PageRequest::consumeContent(std::vector<uint8_t>& buffer) {
     return true;
 }
 
-size_t PageRequest::getUintHeader(const std::string &name) const {
+size_t PageRequest::getUintHeader(const std::string& name) const {
     auto iter = _headers.find(name);
-    if (iter == _headers.end()) return 0u;
+    if (iter == _headers.end())
+        return 0u;
     auto val = atoi(iter->second.c_str());
-    if (val < 0) return 0u;
+    if (val < 0)
+        return 0u;
     return static_cast<size_t>(val);
 }
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/Response.cpp
+++ b/src/main/c/Response.cpp
@@ -36,37 +36,37 @@ std::shared_ptr<Response> Response::unhandled() {
 
 std::shared_ptr<Response> Response::notFound() {
     static std::shared_ptr<Response> notFound = std::make_shared<ConcreteResponse>(
-                                            ResponseCode::NotFound,
-                                            "Not found", "text/plain",
-                                            SynchronousResponse::Headers(), false);
+        ResponseCode::NotFound,
+        "Not found", "text/plain",
+        SynchronousResponse::Headers(), false);
     return notFound;
 }
 
 std::shared_ptr<Response> Response::error(ResponseCode code, const std::string& error) {
     return std::make_shared<ConcreteResponse>(
-                code, error, "text/plain",
-                SynchronousResponse::Headers(), false);
+        code, error, "text/plain",
+        SynchronousResponse::Headers(), false);
 }
 
 std::shared_ptr<Response> Response::textResponse(const std::string& response) {
     return std::make_shared<ConcreteResponse>(
-                ResponseCode::Ok,
-                response, "text/plain",
-                SynchronousResponse::Headers(), true);
+        ResponseCode::Ok,
+        response, "text/plain",
+        SynchronousResponse::Headers(), true);
 }
 
 std::shared_ptr<Response> Response::jsonResponse(const std::string& response) {
     return std::make_shared<ConcreteResponse>(
-                ResponseCode::Ok, response,
-                "application/json",
-                SynchronousResponse::Headers(), true);
+        ResponseCode::Ok, response,
+        "application/json",
+        SynchronousResponse::Headers(), true);
 }
 
 std::shared_ptr<Response> Response::htmlResponse(const std::string& response) {
     return std::make_shared<ConcreteResponse>(
-                ResponseCode::Ok, response,
-                "text/html",
-                SynchronousResponse::Headers(), true);
+        ResponseCode::Ok, response,
+        "text/html",
+        SynchronousResponse::Headers(), true);
 }
 
 }

--- a/src/main/c/StringUtil.cpp
+++ b/src/main/c/StringUtil.cpp
@@ -34,7 +34,8 @@
 namespace seasocks {
 
 char* skipWhitespace(char* str) {
-    while (isspace(*str)) ++str;
+    while (isspace(*str))
+        ++str;
     return str;
 }
 
@@ -64,14 +65,16 @@ char* shift(char*& str) {
 
 std::string trimWhitespace(const std::string& str) {
     auto* start = str.c_str();
-    while (isspace(*start)) ++start;
+    while (isspace(*start))
+        ++start;
     auto* end = &str.back();
-    while (end >= start && isspace(*end)) --end;
+    while (end >= start && isspace(*end))
+        --end;
     return std::string(start, end - start + 1);
 }
 
 
-std::string getLastError(){
+std::string getLastError() {
     char errbuf[1024];
     strerror_r(errno, errbuf, sizeof(errbuf));
     return errbuf;
@@ -90,7 +93,8 @@ std::string formatAddress(const sockaddr_in& address) {
 }
 
 std::vector<std::string> split(const std::string& input, char splitChar) {
-    if (input.empty()) return std::vector<std::string>();
+    if (input.empty())
+        return std::vector<std::string>();
     std::vector<std::string> result;
     size_t pos = 0;
     size_t newPos;
@@ -113,7 +117,7 @@ void replace(std::string& string, const std::string& find,
     }
 }
 
-bool caseInsensitiveSame(const std::string &lhs, const std::string &rhs) {
+bool caseInsensitiveSame(const std::string& lhs, const std::string& rhs) {
     return strcasecmp(lhs.c_str(), rhs.c_str()) == 0;
 }
 
@@ -122,7 +126,7 @@ std::string webtime(time_t time) {
     gmtime_r(&time, &tm);
     char buf[1024];
     // Wed, 20 Apr 2011 17:31:28 GMT
-    strftime(buf, sizeof(buf)-1, "%a, %d %b %Y %H:%M:%S %Z", &tm);
+    strftime(buf, sizeof(buf) - 1, "%a, %d %b %Y %H:%M:%S %Z", &tm);
     return buf;
 }
 

--- a/src/main/c/internal/Base64.cpp
+++ b/src/main/c/internal/Base64.cpp
@@ -28,9 +28,9 @@
 #include <cstdint>
 
 namespace seasocks {
-    namespace {
-        const char cb64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    }
+namespace {
+const char cb64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+}
 
 std::string base64Encode(const void* data, size_t length) {
     std::string output;

--- a/src/main/c/internal/ConcreteResponse.h
+++ b/src/main/c/internal/ConcreteResponse.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -38,9 +38,10 @@ class ConcreteResponse : public SynchronousResponse {
 
 public:
     ConcreteResponse(ResponseCode responseCode, const std::string& payload,
-        const std::string& contentType, const Headers& headers, bool keepAlive) :
-            _responseCode(responseCode), _payload(payload), _contentType(contentType),
-            _headers(headers), _keepAlive(keepAlive) { }
+                     const std::string& contentType, const Headers& headers, bool keepAlive)
+            : _responseCode(responseCode), _payload(payload), _contentType(contentType),
+              _headers(headers), _keepAlive(keepAlive) {
+    }
 
     virtual ResponseCode responseCode() const override {
         return _responseCode;

--- a/src/main/c/internal/Debug.h
+++ b/src/main/c/internal/Debug.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/internal/Embedded.h
+++ b/src/main/c/internal/Embedded.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -28,8 +28,8 @@
 #include <string>
 
 struct EmbeddedContent {
-   const char* data;
-   size_t length;
+    const char* data;
+    size_t length;
 };
 
 const EmbeddedContent* findEmbeddedContent(const std::string& name);

--- a/src/main/c/internal/HeaderMap.h
+++ b/src/main/c/internal/HeaderMap.h
@@ -33,9 +33,9 @@
 namespace seasocks {
 
 struct CaseInsensitiveHash {
-    size_t operator()(const std::string &string) const {
+    size_t operator()(const std::string& string) const {
         size_t h = 0;
-        for (auto c: string) {
+        for (auto c : string) {
             h = h * 13 + tolower(c);
         }
         return h;
@@ -43,12 +43,12 @@ struct CaseInsensitiveHash {
 };
 
 struct CaseInsensitiveComparison {
-    bool operator()(const std::string &lhs, const std::string &rhs) const {
+    bool operator()(const std::string& lhs, const std::string& rhs) const {
         return strcasecmp(lhs.c_str(), rhs.c_str()) == 0;
     }
 };
 
 using HeaderMap = std::unordered_map<std::string, std::string,
-        CaseInsensitiveHash, CaseInsensitiveComparison>;
+                                     CaseInsensitiveHash, CaseInsensitiveComparison>;
 
 }

--- a/src/main/c/internal/HybiAccept.h
+++ b/src/main/c/internal/HybiAccept.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/internal/HybiPacketDecoder.h
+++ b/src/main/c/internal/HybiPacketDecoder.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -38,11 +38,12 @@ class HybiPacketDecoder {
     Logger& _logger;
     const std::vector<uint8_t>& _buffer;
     size_t _messageStart;
+
 public:
     HybiPacketDecoder(Logger& logger, const std::vector<uint8_t>& buffer);
 
     enum class Opcode : uint8_t {
-        Cont = 0x0,  // Deprecated in latest hybi spec, here anyway.
+        Cont = 0x0, // Deprecated in latest hybi spec, here anyway.
         Text = 0x1,
         Binary = 0x2,
         Close = 0x8,

--- a/src/main/c/internal/LogStream.h
+++ b/src/main/c/internal/LogStream.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -30,16 +30,16 @@
 // Internal stream helpers for logging.
 #include <sstream>
 
-#define LS_LOG(LOG, LEVEL, STUFF) \
-{ \
-    std::ostringstream os_; \
-    os_ << STUFF; \
-    (LOG)->log(Logger::Level::LEVEL, os_.str().c_str()); \
-}
+#define LS_LOG(LOG, LEVEL, STUFF)                            \
+    {                                                        \
+        std::ostringstream os_;                              \
+        os_ << STUFF;                                        \
+        (LOG)->log(Logger::Level::LEVEL, os_.str().c_str()); \
+    }
 
-#define LS_DEBUG(LOG, STUFF)     LS_LOG(LOG, Debug, STUFF)
-#define LS_ACCESS(LOG, STUFF)     LS_LOG(LOG, Access, STUFF)
-#define LS_INFO(LOG, STUFF)     LS_LOG(LOG, Info, STUFF)
-#define LS_WARNING(LOG, STUFF)     LS_LOG(LOG, Warning, STUFF)
-#define LS_ERROR(LOG, STUFF)     LS_LOG(LOG, Error, STUFF)
-#define LS_SEVERE(LOG, STUFF)     LS_LOG(LOG, Severe, STUFF)
+#define LS_DEBUG(LOG, STUFF) LS_LOG(LOG, Debug, STUFF)
+#define LS_ACCESS(LOG, STUFF) LS_LOG(LOG, Access, STUFF)
+#define LS_INFO(LOG, STUFF) LS_LOG(LOG, Info, STUFF)
+#define LS_WARNING(LOG, STUFF) LS_LOG(LOG, Warning, STUFF)
+#define LS_ERROR(LOG, STUFF) LS_LOG(LOG, Error, STUFF)
+#define LS_SEVERE(LOG, STUFF) LS_LOG(LOG, Severe, STUFF)

--- a/src/main/c/internal/PageRequest.h
+++ b/src/main/c/internal/PageRequest.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -37,7 +37,7 @@ class PageRequest : public Request {
     std::shared_ptr<Credentials> _credentials;
     const sockaddr_in _remoteAddress;
     const std::string _requestUri;
-    Server &_server;
+    Server& _server;
     const Verb _verb;
     std::vector<uint8_t> _content;
     HeaderMap _headers;
@@ -45,13 +45,15 @@ class PageRequest : public Request {
 
 public:
     PageRequest(
-            const sockaddr_in& remoteAddress,
-            const std::string& requestUri,
-            Server &server,
-            Verb verb,
-            HeaderMap&& headers);
+        const sockaddr_in& remoteAddress,
+        const std::string& requestUri,
+        Server& server,
+        Verb verb,
+        HeaderMap&& headers);
 
-    virtual Server &server() const override { return _server; }
+    virtual Server& server() const override {
+        return _server;
+    }
 
     virtual Verb verb() const override {
         return _verb;
@@ -88,7 +90,7 @@ public:
 
     bool consumeContent(std::vector<uint8_t>& buffer);
 
-    size_t getUintHeader(const std::string &name) const;
+    size_t getUintHeader(const std::string& name) const;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/internal/RaiiFd.h
+++ b/src/main/c/internal/RaiiFd.h
@@ -33,7 +33,8 @@ class RaiiFd {
     int fd_;
 
 public:
-    explicit RaiiFd(int fd) : fd_(fd) {
+    explicit RaiiFd(int fd)
+            : fd_(fd) {
     }
 
     RaiiFd(const RaiiFd&) = delete;

--- a/src/main/c/md5/md5.cpp
+++ b/src/main/c/md5/md5.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 /*
@@ -80,86 +80,86 @@
 
 #include <cstring>
 
-#undef BYTE_ORDER    /* 1 = big-endian, -1 = little-endian, 0 = unknown */
+#undef BYTE_ORDER /* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
-#  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
+#define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
 #else
-#  define BYTE_ORDER 0
+#define BYTE_ORDER 0
 #endif
 
-#define T_MASK ((md5_word_t)~0)
+#define T_MASK ((md5_word_t) ~0)
 #define T1 /* 0xd76aa478 */ (T_MASK ^ 0x28955b87)
 #define T2 /* 0xe8c7b756 */ (T_MASK ^ 0x173848a9)
-#define T3    0x242070db
+#define T3 0x242070db
 #define T4 /* 0xc1bdceee */ (T_MASK ^ 0x3e423111)
 #define T5 /* 0xf57c0faf */ (T_MASK ^ 0x0a83f050)
-#define T6    0x4787c62a
+#define T6 0x4787c62a
 #define T7 /* 0xa8304613 */ (T_MASK ^ 0x57cfb9ec)
 #define T8 /* 0xfd469501 */ (T_MASK ^ 0x02b96afe)
-#define T9    0x698098d8
+#define T9 0x698098d8
 #define T10 /* 0x8b44f7af */ (T_MASK ^ 0x74bb0850)
 #define T11 /* 0xffff5bb1 */ (T_MASK ^ 0x0000a44e)
 #define T12 /* 0x895cd7be */ (T_MASK ^ 0x76a32841)
-#define T13    0x6b901122
+#define T13 0x6b901122
 #define T14 /* 0xfd987193 */ (T_MASK ^ 0x02678e6c)
 #define T15 /* 0xa679438e */ (T_MASK ^ 0x5986bc71)
-#define T16    0x49b40821
+#define T16 0x49b40821
 #define T17 /* 0xf61e2562 */ (T_MASK ^ 0x09e1da9d)
 #define T18 /* 0xc040b340 */ (T_MASK ^ 0x3fbf4cbf)
-#define T19    0x265e5a51
+#define T19 0x265e5a51
 #define T20 /* 0xe9b6c7aa */ (T_MASK ^ 0x16493855)
 #define T21 /* 0xd62f105d */ (T_MASK ^ 0x29d0efa2)
-#define T22    0x02441453
+#define T22 0x02441453
 #define T23 /* 0xd8a1e681 */ (T_MASK ^ 0x275e197e)
 #define T24 /* 0xe7d3fbc8 */ (T_MASK ^ 0x182c0437)
-#define T25    0x21e1cde6
+#define T25 0x21e1cde6
 #define T26 /* 0xc33707d6 */ (T_MASK ^ 0x3cc8f829)
 #define T27 /* 0xf4d50d87 */ (T_MASK ^ 0x0b2af278)
-#define T28    0x455a14ed
+#define T28 0x455a14ed
 #define T29 /* 0xa9e3e905 */ (T_MASK ^ 0x561c16fa)
 #define T30 /* 0xfcefa3f8 */ (T_MASK ^ 0x03105c07)
-#define T31    0x676f02d9
+#define T31 0x676f02d9
 #define T32 /* 0x8d2a4c8a */ (T_MASK ^ 0x72d5b375)
 #define T33 /* 0xfffa3942 */ (T_MASK ^ 0x0005c6bd)
 #define T34 /* 0x8771f681 */ (T_MASK ^ 0x788e097e)
-#define T35    0x6d9d6122
+#define T35 0x6d9d6122
 #define T36 /* 0xfde5380c */ (T_MASK ^ 0x021ac7f3)
 #define T37 /* 0xa4beea44 */ (T_MASK ^ 0x5b4115bb)
-#define T38    0x4bdecfa9
+#define T38 0x4bdecfa9
 #define T39 /* 0xf6bb4b60 */ (T_MASK ^ 0x0944b49f)
 #define T40 /* 0xbebfbc70 */ (T_MASK ^ 0x4140438f)
-#define T41    0x289b7ec6
+#define T41 0x289b7ec6
 #define T42 /* 0xeaa127fa */ (T_MASK ^ 0x155ed805)
 #define T43 /* 0xd4ef3085 */ (T_MASK ^ 0x2b10cf7a)
-#define T44    0x04881d05
+#define T44 0x04881d05
 #define T45 /* 0xd9d4d039 */ (T_MASK ^ 0x262b2fc6)
 #define T46 /* 0xe6db99e5 */ (T_MASK ^ 0x1924661a)
-#define T47    0x1fa27cf8
+#define T47 0x1fa27cf8
 #define T48 /* 0xc4ac5665 */ (T_MASK ^ 0x3b53a99a)
 #define T49 /* 0xf4292244 */ (T_MASK ^ 0x0bd6ddbb)
-#define T50    0x432aff97
+#define T50 0x432aff97
 #define T51 /* 0xab9423a7 */ (T_MASK ^ 0x546bdc58)
 #define T52 /* 0xfc93a039 */ (T_MASK ^ 0x036c5fc6)
-#define T53    0x655b59c3
+#define T53 0x655b59c3
 #define T54 /* 0x8f0ccc92 */ (T_MASK ^ 0x70f3336d)
 #define T55 /* 0xffeff47d */ (T_MASK ^ 0x00100b82)
 #define T56 /* 0x85845dd1 */ (T_MASK ^ 0x7a7ba22e)
-#define T57    0x6fa87e4f
+#define T57 0x6fa87e4f
 #define T58 /* 0xfe2ce6e0 */ (T_MASK ^ 0x01d3191f)
 #define T59 /* 0xa3014314 */ (T_MASK ^ 0x5cfebceb)
-#define T60    0x4e0811a1
+#define T60 0x4e0811a1
 #define T61 /* 0xf7537e82 */ (T_MASK ^ 0x08ac817d)
 #define T62 /* 0xbd3af235 */ (T_MASK ^ 0x42c50dca)
-#define T63    0x2ad7d2bb
+#define T63 0x2ad7d2bb
 #define T64 /* 0xeb86d391 */ (T_MASK ^ 0x14792c6e)
 
 
 static void
-md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
-{
+md5_process(md5_state_t* pms, const md5_byte_t* data /*[64]*/) {
     md5_word_t
-    a = pms->abcd[0], b = pms->abcd[1],
-    c = pms->abcd[2], d = pms->abcd[3];
+        a = pms->abcd[0],
+        b = pms->abcd[1],
+        c = pms->abcd[2], d = pms->abcd[3];
     md5_word_t t;
 #if BYTE_ORDER > 0
     /* Define storage only for big-endian CPUs. */
@@ -167,56 +167,56 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 #else
     /* Define storage for little-endian or both types of CPUs. */
     md5_word_t xbuf[16];
-    const md5_word_t *X;
+    const md5_word_t* X;
 #endif
 
     {
 #if BYTE_ORDER == 0
-    /*
+        /*
      * Determine dynamically whether this is a big-endian or
      * little-endian machine, since we can use a more efficient
      * algorithm on the latter.
      */
-    static const int w = 1;
+        static const int w = 1;
 
-    if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
+        if (*((const md5_byte_t*) &w)) /* dynamic little-endian */
 #endif
-#if BYTE_ORDER <= 0        /* little-endian */
-    {
-        /*
+#if BYTE_ORDER <= 0 /* little-endian */
+        {
+            /*
          * On little-endian machines, we can process properly aligned
          * data without copying it.
          */
-        if (!((data - (const md5_byte_t *)0) & 3)) {
-        /* data are properly aligned */
-        X = (const md5_word_t *)data;
-        } else {
-        /* not aligned */
-        memcpy(xbuf, data, 64);
-        X = xbuf;
+            if (!((data - (const md5_byte_t*) 0) & 3)) {
+                /* data are properly aligned */
+                X = (const md5_word_t*) data;
+            } else {
+                /* not aligned */
+                memcpy(xbuf, data, 64);
+                X = xbuf;
+            }
         }
-    }
 #endif
 #if BYTE_ORDER == 0
-    else            /* dynamic big-endian */
+        else /* dynamic big-endian */
 #endif
-#if BYTE_ORDER >= 0        /* big-endian */
-    {
-        /*
+#if BYTE_ORDER >= 0 /* big-endian */
+        {
+            /*
          * On big-endian machines, we must arrange the bytes in the
          * right order.
          */
-        const md5_byte_t *xp = data;
-        int i;
+            const md5_byte_t* xp = data;
+            int i;
 
-#  if BYTE_ORDER == 0
-        X = xbuf;        /* (dynamic only) */
-#  else
-#    define xbuf X        /* (static only) */
-#  endif
-        for (i = 0; i < 16; ++i, xp += 4)
-        xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
-    }
+#if BYTE_ORDER == 0
+            X = xbuf; /* (dynamic only) */
+#else
+#define xbuf X /* (static only) */
+#endif
+            for (i = 0; i < 16; ++i, xp += 4)
+                xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+        }
 #endif
     }
 
@@ -226,107 +226,107 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
     /* Let [abcd k s i] denote the operation
        a = b + ((a + F(b,c,d) + X[k] + T[i]) <<< s). */
 #define F(x, y, z) (((x) & (y)) | (~(x) & (z)))
-#define SET(a, b, c, d, k, s, Ti)\
-  t = a + F(b,c,d) + X[k] + Ti;\
-  a = ROTATE_LEFT(t, s) + b
+#define SET(a, b, c, d, k, s, Ti)   \
+    t = a + F(b, c, d) + X[k] + Ti; \
+    a = ROTATE_LEFT(t, s) + b
     /* Do the following 16 operations. */
-    SET(a, b, c, d,  0,  7,  T1);
-    SET(d, a, b, c,  1, 12,  T2);
-    SET(c, d, a, b,  2, 17,  T3);
-    SET(b, c, d, a,  3, 22,  T4);
-    SET(a, b, c, d,  4,  7,  T5);
-    SET(d, a, b, c,  5, 12,  T6);
-    SET(c, d, a, b,  6, 17,  T7);
-    SET(b, c, d, a,  7, 22,  T8);
-    SET(a, b, c, d,  8,  7,  T9);
-    SET(d, a, b, c,  9, 12, T10);
+    SET(a, b, c, d, 0, 7, T1);
+    SET(d, a, b, c, 1, 12, T2);
+    SET(c, d, a, b, 2, 17, T3);
+    SET(b, c, d, a, 3, 22, T4);
+    SET(a, b, c, d, 4, 7, T5);
+    SET(d, a, b, c, 5, 12, T6);
+    SET(c, d, a, b, 6, 17, T7);
+    SET(b, c, d, a, 7, 22, T8);
+    SET(a, b, c, d, 8, 7, T9);
+    SET(d, a, b, c, 9, 12, T10);
     SET(c, d, a, b, 10, 17, T11);
     SET(b, c, d, a, 11, 22, T12);
-    SET(a, b, c, d, 12,  7, T13);
+    SET(a, b, c, d, 12, 7, T13);
     SET(d, a, b, c, 13, 12, T14);
     SET(c, d, a, b, 14, 17, T15);
     SET(b, c, d, a, 15, 22, T16);
 #undef SET
 
-     /* Round 2. */
-     /* Let [abcd k s i] denote the operation
+    /* Round 2. */
+    /* Let [abcd k s i] denote the operation
           a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
 #define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
-#define SET(a, b, c, d, k, s, Ti)\
-  t = a + G(b,c,d) + X[k] + Ti;\
-  a = ROTATE_LEFT(t, s) + b
-     /* Do the following 16 operations. */
-    SET(a, b, c, d,  1,  5, T17);
-    SET(d, a, b, c,  6,  9, T18);
+#define SET(a, b, c, d, k, s, Ti)   \
+    t = a + G(b, c, d) + X[k] + Ti; \
+    a = ROTATE_LEFT(t, s) + b
+    /* Do the following 16 operations. */
+    SET(a, b, c, d, 1, 5, T17);
+    SET(d, a, b, c, 6, 9, T18);
     SET(c, d, a, b, 11, 14, T19);
-    SET(b, c, d, a,  0, 20, T20);
-    SET(a, b, c, d,  5,  5, T21);
-    SET(d, a, b, c, 10,  9, T22);
+    SET(b, c, d, a, 0, 20, T20);
+    SET(a, b, c, d, 5, 5, T21);
+    SET(d, a, b, c, 10, 9, T22);
     SET(c, d, a, b, 15, 14, T23);
-    SET(b, c, d, a,  4, 20, T24);
-    SET(a, b, c, d,  9,  5, T25);
-    SET(d, a, b, c, 14,  9, T26);
-    SET(c, d, a, b,  3, 14, T27);
-    SET(b, c, d, a,  8, 20, T28);
-    SET(a, b, c, d, 13,  5, T29);
-    SET(d, a, b, c,  2,  9, T30);
-    SET(c, d, a, b,  7, 14, T31);
+    SET(b, c, d, a, 4, 20, T24);
+    SET(a, b, c, d, 9, 5, T25);
+    SET(d, a, b, c, 14, 9, T26);
+    SET(c, d, a, b, 3, 14, T27);
+    SET(b, c, d, a, 8, 20, T28);
+    SET(a, b, c, d, 13, 5, T29);
+    SET(d, a, b, c, 2, 9, T30);
+    SET(c, d, a, b, 7, 14, T31);
     SET(b, c, d, a, 12, 20, T32);
 #undef SET
 
-     /* Round 3. */
-     /* Let [abcd k s t] denote the operation
+    /* Round 3. */
+    /* Let [abcd k s t] denote the operation
           a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
 #define H(x, y, z) ((x) ^ (y) ^ (z))
-#define SET(a, b, c, d, k, s, Ti)\
-  t = a + H(b,c,d) + X[k] + Ti;\
-  a = ROTATE_LEFT(t, s) + b
-     /* Do the following 16 operations. */
-    SET(a, b, c, d,  5,  4, T33);
-    SET(d, a, b, c,  8, 11, T34);
+#define SET(a, b, c, d, k, s, Ti)   \
+    t = a + H(b, c, d) + X[k] + Ti; \
+    a = ROTATE_LEFT(t, s) + b
+    /* Do the following 16 operations. */
+    SET(a, b, c, d, 5, 4, T33);
+    SET(d, a, b, c, 8, 11, T34);
     SET(c, d, a, b, 11, 16, T35);
     SET(b, c, d, a, 14, 23, T36);
-    SET(a, b, c, d,  1,  4, T37);
-    SET(d, a, b, c,  4, 11, T38);
-    SET(c, d, a, b,  7, 16, T39);
+    SET(a, b, c, d, 1, 4, T37);
+    SET(d, a, b, c, 4, 11, T38);
+    SET(c, d, a, b, 7, 16, T39);
     SET(b, c, d, a, 10, 23, T40);
-    SET(a, b, c, d, 13,  4, T41);
-    SET(d, a, b, c,  0, 11, T42);
-    SET(c, d, a, b,  3, 16, T43);
-    SET(b, c, d, a,  6, 23, T44);
-    SET(a, b, c, d,  9,  4, T45);
+    SET(a, b, c, d, 13, 4, T41);
+    SET(d, a, b, c, 0, 11, T42);
+    SET(c, d, a, b, 3, 16, T43);
+    SET(b, c, d, a, 6, 23, T44);
+    SET(a, b, c, d, 9, 4, T45);
     SET(d, a, b, c, 12, 11, T46);
     SET(c, d, a, b, 15, 16, T47);
-    SET(b, c, d, a,  2, 23, T48);
+    SET(b, c, d, a, 2, 23, T48);
 #undef SET
 
-     /* Round 4. */
-     /* Let [abcd k s t] denote the operation
+    /* Round 4. */
+    /* Let [abcd k s t] denote the operation
           a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
 #define I(x, y, z) ((y) ^ ((x) | ~(z)))
-#define SET(a, b, c, d, k, s, Ti)\
-  t = a + I(b,c,d) + X[k] + Ti;\
-  a = ROTATE_LEFT(t, s) + b
-     /* Do the following 16 operations. */
-    SET(a, b, c, d,  0,  6, T49);
-    SET(d, a, b, c,  7, 10, T50);
+#define SET(a, b, c, d, k, s, Ti)   \
+    t = a + I(b, c, d) + X[k] + Ti; \
+    a = ROTATE_LEFT(t, s) + b
+    /* Do the following 16 operations. */
+    SET(a, b, c, d, 0, 6, T49);
+    SET(d, a, b, c, 7, 10, T50);
     SET(c, d, a, b, 14, 15, T51);
-    SET(b, c, d, a,  5, 21, T52);
-    SET(a, b, c, d, 12,  6, T53);
-    SET(d, a, b, c,  3, 10, T54);
+    SET(b, c, d, a, 5, 21, T52);
+    SET(a, b, c, d, 12, 6, T53);
+    SET(d, a, b, c, 3, 10, T54);
     SET(c, d, a, b, 10, 15, T55);
-    SET(b, c, d, a,  1, 21, T56);
-    SET(a, b, c, d,  8,  6, T57);
+    SET(b, c, d, a, 1, 21, T56);
+    SET(a, b, c, d, 8, 6, T57);
     SET(d, a, b, c, 15, 10, T58);
-    SET(c, d, a, b,  6, 15, T59);
+    SET(c, d, a, b, 6, 15, T59);
     SET(b, c, d, a, 13, 21, T60);
-    SET(a, b, c, d,  4,  6, T61);
+    SET(a, b, c, d, 4, 6, T61);
     SET(d, a, b, c, 11, 10, T62);
-    SET(c, d, a, b,  2, 15, T63);
-    SET(b, c, d, a,  9, 21, T64);
+    SET(c, d, a, b, 2, 15, T63);
+    SET(b, c, d, a, 9, 21, T64);
 #undef SET
 
-     /* Then perform the following additions. (That is increment each
+    /* Then perform the following additions. (That is increment each
         of the four registers by the value it had before this block
         was started.) */
     pms->abcd[0] += a;
@@ -336,13 +336,10 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 }
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-void
-md5_init(md5_state_t *pms)
-{
+void md5_init(md5_state_t* pms) {
     pms->count[0] = pms->count[1] = 0;
     pms->abcd[0] = 0x67452301;
     pms->abcd[1] = /*0xefcdab89*/ T_MASK ^ 0x10325476;
@@ -350,67 +347,62 @@ md5_init(md5_state_t *pms)
     pms->abcd[3] = 0x10325476;
 }
 
-void
-md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
-{
-    const md5_byte_t *p = data;
+void md5_append(md5_state_t* pms, const md5_byte_t* data, int nbytes) {
+    const md5_byte_t* p = data;
     int left = nbytes;
     int offset = (pms->count[0] >> 3) & 63;
     md5_word_t nbits = (md5_word_t)(nbytes << 3);
 
     if (nbytes <= 0)
-    return;
+        return;
 
     /* Update the message length. */
     pms->count[1] += nbytes >> 29;
     pms->count[0] += nbits;
     if (pms->count[0] < nbits)
-    pms->count[1]++;
+        pms->count[1]++;
 
     /* Process an initial partial block. */
     if (offset) {
-    int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+        int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
 
-    memcpy(pms->buf + offset, p, copy);
-    if (offset + copy < 64)
-        return;
-    p += copy;
-    left -= copy;
-    md5_process(pms, pms->buf);
+        memcpy(pms->buf + offset, p, copy);
+        if (offset + copy < 64)
+            return;
+        p += copy;
+        left -= copy;
+        md5_process(pms, pms->buf);
     }
 
     /* Process full blocks. */
     for (; left >= 64; p += 64, left -= 64)
-    md5_process(pms, p);
+        md5_process(pms, p);
 
     /* Process a final partial block. */
     if (left)
-    memcpy(pms->buf, p, left);
+        memcpy(pms->buf, p, left);
 }
 
-void
-md5_finish(md5_state_t *pms, md5_byte_t digest[16])
-{
+void md5_finish(md5_state_t* pms, md5_byte_t digest[16]) {
     static const md5_byte_t pad[64] = {
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-    };
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     md5_byte_t data[8];
     int i;
 
     /* Save the length before padding. */
     for (i = 0; i < 8; ++i)
-    data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
+        data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
     /* Pad to 56 bytes mod 64. */
     md5_append(pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
     /* Append the length. */
     md5_append(pms, data, 8);
     for (i = 0; i < 16; ++i)
-    digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
+        digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
 }
 
 #ifdef __cplusplus
-}  /* end extern "C" */
+} /* end extern "C" */
 #endif

--- a/src/main/c/md5/md5.h
+++ b/src/main/c/md5/md5.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 /*
@@ -73,7 +73,7 @@
  */
 
 #ifndef md5_INCLUDED
-#  define md5_INCLUDED
+#define md5_INCLUDED
 
 /*
  * This package supports both compile-time and run-time determination of CPU
@@ -86,31 +86,30 @@
  */
 
 using md5_byte_t = unsigned char; /* 8-bit byte */
-using md5_word_t = unsigned int; /* 32-bit word */
+using md5_word_t = unsigned int;  /* 32-bit word */
 
 /* Define the state of the MD5 Algorithm. */
 typedef struct md5_state_s {
-    md5_word_t count[2];    /* message length in bits, lsw first */
-    md5_word_t abcd[4];        /* digest buffer */
-    md5_byte_t buf[64];        /* accumulate block */
+    md5_word_t count[2]; /* message length in bits, lsw first */
+    md5_word_t abcd[4];  /* digest buffer */
+    md5_byte_t buf[64];  /* accumulate block */
 } md5_state_t;
 
 #ifdef __cplusplus
-extern "C" 
-{
+extern "C" {
 #endif
 
 /* Initialize the algorithm. */
-void md5_init(md5_state_t *pms);
+void md5_init(md5_state_t* pms);
 
 /* Append a string to the message. */
-void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
+void md5_append(md5_state_t* pms, const md5_byte_t* data, int nbytes);
 
 /* Finish the message and return the digest. */
-void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+void md5_finish(md5_state_t* pms, md5_byte_t digest[16]);
 
 #ifdef __cplusplus
-}  /* end extern "C" */
+} /* end extern "C" */
 #endif
 
 #endif /* md5_INCLUDED */

--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -52,17 +52,19 @@ class Response;
 class Connection : public WebSocket {
 public:
     Connection(
-            std::shared_ptr<Logger> logger,
-            ServerImpl& server,
-            int fd,
-            const sockaddr_in& address);
+        std::shared_ptr<Logger> logger,
+        ServerImpl& server,
+        int fd,
+        const sockaddr_in& address);
     virtual ~Connection();
 
     bool write(const void* data, size_t size, bool flush);
     void handleDataReadyForRead();
     void handleDataReadyForWrite();
 
-    int getFd() const { return _fd; }
+    int getFd() const {
+        return _fd;
+    }
 
     // From WebSocket.
     virtual void send(const char* webSocketResponse) override;
@@ -71,25 +73,43 @@ public:
 
     // From Request.
     virtual std::shared_ptr<Credentials> credentials() const override;
-    virtual const sockaddr_in& getRemoteAddress() const override { return _address; }
+    virtual const sockaddr_in& getRemoteAddress() const override {
+        return _address;
+    }
     virtual const std::string& getRequestUri() const override;
-    virtual Request::Verb verb() const override { return Request::Verb::WebSocket; }
-    virtual size_t contentLength() const override { return 0; }
-    virtual const uint8_t* content() const override { return nullptr; }
+    virtual Request::Verb verb() const override {
+        return Request::Verb::WebSocket;
+    }
+    virtual size_t contentLength() const override {
+        return 0;
+    }
+    virtual const uint8_t* content() const override {
+        return nullptr;
+    }
     virtual bool hasHeader(const std::string&) const override;
     virtual std::string getHeader(const std::string&) const override;
-    virtual Server &server() const override;
+    virtual Server& server() const override;
 
     void setLinger();
 
-    size_t inputBufferSize() const { return _inBuf.size(); }
-    size_t outputBufferSize() const { return _outBuf.size(); }
+    size_t inputBufferSize() const {
+        return _inBuf.size();
+    }
+    size_t outputBufferSize() const {
+        return _outBuf.size();
+    }
 
-    size_t bytesReceived() const { return _bytesReceived; }
-    size_t bytesSent() const { return _bytesSent; }
+    size_t bytesReceived() const {
+        return _bytesReceived;
+    }
+    size_t bytesSent() const {
+        return _bytesSent;
+    }
 
     // For testing:
-    std::vector<uint8_t>& getInputBuffer() { return _inBuf; }
+    std::vector<uint8_t>& getInputBuffer() {
+        return _inBuf;
+    }
     void handleHixieWebSocket();
     void handleHybiWebSocket();
     void setHandler(std::shared_ptr<WebSocket::Handler> handler) {
@@ -99,7 +119,7 @@ public:
 
 
     Connection(Connection& other) = delete;
-    Connection& operator =(Connection& other) = delete;
+    Connection& operator=(Connection& other) = delete;
 
 
 private:
@@ -145,15 +165,17 @@ private:
     // Delegated from ResponseWriter.
     struct Writer;
     void begin(ResponseCode responseCode, TransferEncoding encoding);
-    void header(const std::string &header, const std::string &value);
-    void payload(const void *data, size_t size, bool flush);
+    void header(const std::string& header, const std::string& value);
+    void payload(const void* data, size_t size, bool flush);
     void finish(bool keepConnectionOpen);
-    void error(ResponseCode responseCode, const std::string &payload);
+    void error(ResponseCode responseCode, const std::string& payload);
 
     struct Range {
         long start;
         long end;
-        size_t length() const { return end - start + 1; }
+        size_t length() const {
+            return end - start + 1;
+        }
     };
 
     bool parseRange(const std::string& rangeStr, Range& range) const;
@@ -167,7 +189,7 @@ private:
     std::list<Range> processRangesForStaticData(const std::list<Range>& ranges, long fileSize);
 
     std::shared_ptr<Logger> _logger;
-    ServerImpl &_server;
+    ServerImpl& _server;
     int _fd;
     bool _shutdown;
     bool _hadSendError;
@@ -208,4 +230,4 @@ private:
     void writeChunkHeader(size_t size);
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/Credentials.h
+++ b/src/main/c/seasocks/Credentials.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -53,21 +53,25 @@ struct Credentials {
      */
     std::map<std::string, std::string> attributes;
 
-    Credentials(): authenticated(false),username(),groups(),attributes() {}
+    Credentials()
+            : authenticated(false), username(), groups(), attributes() {
+    }
 };
 
-inline std::ostream &operator<<(std::ostream &os, const Credentials& credentials) {
+inline std::ostream& operator<<(std::ostream& os, const Credentials& credentials) {
     os << "{authenticated:" << credentials.authenticated << ", username:'" << credentials.username << "', groups: {";
     for (auto it = credentials.groups.begin(); it != credentials.groups.end(); ++it) {
-        if (it != credentials.groups.begin()) os << ", ";
+        if (it != credentials.groups.begin())
+            os << ", ";
         os << *it;
     }
     os << "}, attrs: {";
     for (auto it = credentials.attributes.begin(); it != credentials.attributes.end(); ++it) {
-        if (it != credentials.attributes.begin()) os << ", ";
+        if (it != credentials.attributes.begin())
+            os << ", ";
         os << it->first << "=" << it->second;
     }
     return os << "}}";
 }
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/IgnoringLogger.h
+++ b/src/main/c/seasocks/IgnoringLogger.h
@@ -35,4 +35,4 @@ public:
     }
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/Logger.h
+++ b/src/main/c/seasocks/Logger.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -54,15 +54,22 @@ public:
 
     static const char* levelToString(Level level) {
         switch (level) {
-        case Level::Debug: return "debug";
-        case Level::Access: return "access";
-        case Level::Info: return "info";
-        case Level::Warning: return "warning";
-        case Level::Error: return "ERROR";
-        case Level::Severe: return "SEVERE";
-        default: return "???";
+            case Level::Debug:
+                return "debug";
+            case Level::Access:
+                return "access";
+            case Level::Info:
+                return "info";
+            case Level::Warning:
+                return "warning";
+            case Level::Error:
+                return "ERROR";
+            case Level::Severe:
+                return "SEVERE";
+            default:
+                return "???";
         }
     }
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/PageHandler.h
+++ b/src/main/c/seasocks/PageHandler.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/seasocks/PrintfLogger.h
+++ b/src/main/c/seasocks/PrintfLogger.h
@@ -33,7 +33,8 @@ namespace seasocks {
 
 class PrintfLogger : public Logger {
 public:
-    explicit PrintfLogger(Level minLevelToLog_ = Level::Debug) : minLevelToLog(minLevelToLog_) {
+    explicit PrintfLogger(Level minLevelToLog_ = Level::Debug)
+            : minLevelToLog(minLevelToLog_) {
     }
 
     ~PrintfLogger() = default;
@@ -47,4 +48,4 @@ public:
     Level minLevelToLog;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/Request.cpp
+++ b/src/main/c/seasocks/Request.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "seasocks/Request.h"
@@ -30,25 +30,38 @@
 namespace seasocks {
 
 const char* Request::name(Verb v) {
-    switch(v) {
-    case Verb::Invalid: return "Invalid";
-    case Verb::WebSocket: return "WebSocket";
-    case Verb::Get: return "Get";
-    case Verb::Put: return "Put";
-    case Verb::Post: return "Post";
-    case Verb::Delete: return "Delete";
-    case Verb::Head: return "Head";
-    default: return "???";
+    switch (v) {
+        case Verb::Invalid:
+            return "Invalid";
+        case Verb::WebSocket:
+            return "WebSocket";
+        case Verb::Get:
+            return "Get";
+        case Verb::Put:
+            return "Put";
+        case Verb::Post:
+            return "Post";
+        case Verb::Delete:
+            return "Delete";
+        case Verb::Head:
+            return "Head";
+        default:
+            return "???";
     }
 }
 
 Request::Verb Request::verb(const char* verb) {
-    if (std::strcmp(verb, "GET") == 0) return Request::Verb::Get;
-    if (std::strcmp(verb, "PUT") == 0) return Request::Verb::Put;
-    if (std::strcmp(verb, "POST") == 0) return Request::Verb::Post;
-    if (std::strcmp(verb, "DELETE") == 0) return Request::Verb::Delete;
-    if (std::strcmp(verb, "HEAD") == 0) return Request::Verb::Head;
+    if (std::strcmp(verb, "GET") == 0)
+        return Request::Verb::Get;
+    if (std::strcmp(verb, "PUT") == 0)
+        return Request::Verb::Put;
+    if (std::strcmp(verb, "POST") == 0)
+        return Request::Verb::Post;
+    if (std::strcmp(verb, "DELETE") == 0)
+        return Request::Verb::Delete;
+    if (std::strcmp(verb, "HEAD") == 0)
+        return Request::Verb::Head;
     return Request::Verb::Invalid;
 }
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/Request.h
+++ b/src/main/c/seasocks/Request.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -50,12 +50,12 @@ public:
         Head,
     };
 
-    virtual Server &server() const = 0;
+    virtual Server& server() const = 0;
 
     virtual Verb verb() const = 0;
 
     static const char* name(Verb v);
-    static Verb verb(const char *verb);
+    static Verb verb(const char* verb);
 
     /**
      * Returns the credentials associated with this request.
@@ -75,4 +75,4 @@ public:
     virtual std::string getHeader(const std::string& name) const = 0;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/Response.h
+++ b/src/main/c/seasocks/Response.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2015, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/seasocks/ResponseBuilder.cpp
+++ b/src/main/c/seasocks/ResponseBuilder.cpp
@@ -29,12 +29,11 @@
 
 namespace seasocks {
 
-ResponseBuilder::ResponseBuilder(ResponseCode code) :
-        _code(code),
-        _contentType("text/plain"),
-        _keepAlive(true),
-        _stream(std::make_shared<std::ostringstream>()) {
-
+ResponseBuilder::ResponseBuilder(ResponseCode code)
+        : _code(code),
+          _contentType("text/plain"),
+          _keepAlive(true),
+          _stream(std::make_shared<std::ostringstream>()) {
 }
 
 ResponseBuilder& ResponseBuilder::asHtml() {

--- a/src/main/c/seasocks/ResponseBuilder.h
+++ b/src/main/c/seasocks/ResponseBuilder.h
@@ -39,6 +39,7 @@ class ResponseBuilder {
     bool _keepAlive;
     SynchronousResponse::Headers _headers;
     std::shared_ptr<std::ostringstream> _stream;
+
 public:
     explicit ResponseBuilder(ResponseCode code = ResponseCode::Ok);
 
@@ -55,19 +56,19 @@ public:
     ResponseBuilder& setsCookie(const std::string& cookie, const std::string& value);
 
     ResponseBuilder& withHeader(const std::string& name, const std::string& value);
-    template<typename T>
+    template <typename T>
     ResponseBuilder& withHeader(const std::string& name, const T& t) {
         return withHeader(name, toString(t));
     }
 
     ResponseBuilder& addHeader(const std::string& name, const std::string& value);
-    template<typename T>
+    template <typename T>
     ResponseBuilder& addHeader(const std::string& name, const T& t) {
         return addHeader(name, toString(t));
     }
 
-    template<typename T>
-    ResponseBuilder& operator << (T&& t) {
+    template <typename T>
+    ResponseBuilder& operator<<(T&& t) {
         (*_stream) << std::forward<T>(t);
         return *this;
     }

--- a/src/main/c/seasocks/ResponseCode.cpp
+++ b/src/main/c/seasocks/ResponseCode.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "seasocks/ResponseCode.h"
@@ -33,7 +33,9 @@ bool isOk(seasocks::ResponseCode code) {
 
 const char* name(ResponseCode code) {
     switch (code) {
-#define SEASOCKS_DEFINE_RESPONSECODE(CODE,SYMBOLICNAME,STRINGNAME) case ResponseCode::SYMBOLICNAME: return STRINGNAME;
+#define SEASOCKS_DEFINE_RESPONSECODE(CODE, SYMBOLICNAME, STRINGNAME) \
+    case ResponseCode::SYMBOLICNAME:                                 \
+        return STRINGNAME;
 #include "seasocks/ResponseCodeDefs.h"
 
 #undef SEASOCKS_DEFINE_RESPONSECODE

--- a/src/main/c/seasocks/ResponseCode.h
+++ b/src/main/c/seasocks/ResponseCode.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -29,7 +29,7 @@
 
 namespace seasocks {
 
-#define SEASOCKS_DEFINE_RESPONSECODE(CODE,SYMBOLICNAME,STRINGNAME) SYMBOLICNAME = CODE,
+#define SEASOCKS_DEFINE_RESPONSECODE(CODE, SYMBOLICNAME, STRINGNAME) SYMBOLICNAME = CODE,
 enum class ResponseCode {
 #include "seasocks/ResponseCodeDefs.h"
 

--- a/src/main/c/seasocks/ResponseCodeDefs.h
+++ b/src/main/c/seasocks/ResponseCodeDefs.h
@@ -1,32 +1,32 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Not a normal header file - no header guards on purpose.
 // Do not directly include! Use ResponseCode.h instead
 
-#ifdef SEASOCKS_DEFINE_RESPONSECODE  // workaround for header check
+#ifdef SEASOCKS_DEFINE_RESPONSECODE // workaround for header check
 
 SEASOCKS_DEFINE_RESPONSECODE(100, Continue, "Continue")
 SEASOCKS_DEFINE_RESPONSECODE(101, WebSocketProtocolHandshake, "WebSocket Protocol Handshake")

--- a/src/main/c/seasocks/ResponseWriter.h
+++ b/src/main/c/seasocks/ResponseWriter.h
@@ -49,12 +49,12 @@ public:
                        TransferEncoding encoding = TransferEncoding::Raw) = 0;
     // Add a header. Must be called after 'begin' and before 'payload'. May be
     // called as many times as needed.
-    virtual void header(const std::string &header, const std::string &value) = 0;
+    virtual void header(const std::string& header, const std::string& value) = 0;
     // Add some payload data. Must be called after 'begin' and any 'header' calls.
     // May be called multiple times. The flush parameter controls whether the
     // data should be sent immediately, or buffered to be sent with a subsequent
     // call to 'payload', or 'finish'.
-    virtual void payload(const void* data, size_t size, bool flush=true) = 0;
+    virtual void payload(const void* data, size_t size, bool flush = true) = 0;
     // Finish a response.
     virtual void finish(bool keepConnectionOpen) = 0;
 
@@ -62,7 +62,7 @@ public:
     // or 'finish' should be executed. If you wish to serve your own error document
     // then use the normal 'begin'/'header'/'payload'/'finish' process but with
     // an error code. This routine is to get Seasocks to generate its own error.
-    virtual void error(ResponseCode responseCode, const std::string &payload) = 0;
+    virtual void error(ResponseCode responseCode, const std::string& payload) = 0;
     // Check whether this writer is still active; i.e. the underlying connection
     // is still open.
     virtual bool isActive() const = 0;

--- a/src/main/c/seasocks/Server.h
+++ b/src/main/c/seasocks/Server.h
@@ -56,7 +56,7 @@ public:
     void addPageHandler(std::shared_ptr<PageHandler> handler);
 
     void addWebSocketHandler(const char* endpoint, std::shared_ptr<WebSocket::Handler> handler,
-            bool allowCrossOriginRequests = false);
+                             bool allowCrossOriginRequests = false);
 
     // Serves static content from the given port on the current thread, until terminate is called.
     // Roughly equivalent to startListening(port); setStaticPath(staticPath); loop();
@@ -96,7 +96,9 @@ public:
     // Returns a file descriptor that can be polled for changes (e.g. by
     // placing it in an epoll set. The poll() method above only need be called
     // when this file descriptor is readable.
-    int fd() const { return _epollFd; }
+    int fd() const {
+        return _epollFd;
+    }
 
     // Terminate any loop() or poll(). May be called from any thread.
     void terminate();
@@ -117,10 +119,14 @@ public:
     // is available here too.
     static constexpr size_t DefaultClientBufferSize = 16 * 1024 * 1024u;
     void setClientBufferSize(size_t bytesToBuffer);
-    size_t clientBufferSize() const override { return _clientBufferSize; }
+    size_t clientBufferSize() const override {
+        return _clientBufferSize;
+    }
 
     void setPerMessageDeflateEnabled(bool enabled);
-    bool getPerMessageDeflateEnabled() { return _perMessageDeflateEnabled;}
+    bool getPerMessageDeflateEnabled() {
+        return _perMessageDeflateEnabled;
+    }
 
     class Runnable {
     public:
@@ -137,13 +143,17 @@ private:
     virtual void remove(Connection* connection) override;
     virtual bool subscribeToWriteEvents(Connection* connection) override;
     virtual bool unsubscribeFromWriteEvents(Connection* connection) override;
-    virtual const std::string& getStaticPath() const override { return _staticPath; }
+    virtual const std::string& getStaticPath() const override {
+        return _staticPath;
+    }
     virtual std::shared_ptr<WebSocket::Handler> getWebSocketHandler(const char* endpoint) const override;
-    virtual bool isCrossOriginAllowed(const std::string &endpoint) const override;
-    virtual std::shared_ptr<Response> handle(const Request &request) override;
+    virtual bool isCrossOriginAllowed(const std::string& endpoint) const override;
+    virtual std::shared_ptr<Response> handle(const Request& request) override;
     virtual std::string getStatsDocument() const override;
     virtual void checkThread() const override;
-    virtual Server &server() override { return *this; }
+    virtual Server& server() override {
+        return *this;
+    }
 
     bool makeNonBlocking(int fd) const;
     bool configureSocket(int fd) const;
@@ -155,7 +165,8 @@ private:
 
     void checkAndDispatchEpoll(int epollMillis);
     void handlePipe();
-    enum class NewState { KeepOpen, Close };
+    enum class NewState { KeepOpen,
+                          Close };
     NewState handleConnectionEvents(Connection* connection, uint32_t events);
 
     // Connections, mapped to initial connection time.
@@ -191,4 +202,4 @@ private:
     std::atomic<bool> _expectedTerminate;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/ServerImpl.h
+++ b/src/main/c/seasocks/ServerImpl.h
@@ -46,11 +46,11 @@ public:
     virtual bool unsubscribeFromWriteEvents(Connection* connection) = 0;
     virtual const std::string& getStaticPath() const = 0;
     virtual std::shared_ptr<WebSocket::Handler> getWebSocketHandler(const char* endpoint) const = 0;
-    virtual bool isCrossOriginAllowed(const std::string &endpoint) const = 0;
-    virtual std::shared_ptr<Response> handle(const Request &request) = 0;
+    virtual bool isCrossOriginAllowed(const std::string& endpoint) const = 0;
+    virtual std::shared_ptr<Response> handle(const Request& request) = 0;
     virtual std::string getStatsDocument() const = 0;
     virtual void checkThread() const = 0;
-    virtual Server &server() = 0;
+    virtual Server& server() = 0;
     virtual size_t clientBufferSize() const = 0;
 };
 

--- a/src/main/c/seasocks/SimpleResponse.h
+++ b/src/main/c/seasocks/SimpleResponse.h
@@ -42,12 +42,13 @@ public:
     static constexpr size_t DefaultBufferSize = 16 * 1024 * 1024u;
 
     SimpleResponse(ResponseCode responseCode, std::shared_ptr<std::istream> stream,
-    const Headers& headers, bool keepAlive = true, bool flushInstantly = false,
-    size_t bufferSize = DefaultBufferSize,
-    TransferEncoding transferEncoding = TransferEncoding::Raw):
-        _responseCode(responseCode), _stream(stream), _headers(headers),
-        _keepAlive(keepAlive), _flushInstantly(flushInstantly),
-        _bufferSize(bufferSize), _transferEncoding(transferEncoding) { }
+                   const Headers& headers, bool keepAlive = true, bool flushInstantly = false,
+                   size_t bufferSize = DefaultBufferSize,
+                   TransferEncoding transferEncoding = TransferEncoding::Raw)
+            : _responseCode(responseCode), _stream(stream), _headers(headers),
+              _keepAlive(keepAlive), _flushInstantly(flushInstantly),
+              _bufferSize(bufferSize), _transferEncoding(transferEncoding) {
+    }
 
     virtual std::shared_ptr<std::istream> getStream() const override {
         return _stream;
@@ -79,4 +80,3 @@ public:
 };
 
 }
-

--- a/src/main/c/seasocks/StreamingResponse.cpp
+++ b/src/main/c/seasocks/StreamingResponse.cpp
@@ -33,7 +33,7 @@ void StreamingResponse::handle(std::shared_ptr<ResponseWriter> writer) {
     writer->begin(responseCode(), transferEncoding());
 
     auto headers = getHeaders();
-    for (auto & header : headers) {
+    for (auto& header : headers) {
         writer->header(header.first, header.second);
     }
 
@@ -67,4 +67,3 @@ void StreamingResponse::handle(std::shared_ptr<ResponseWriter> writer) {
 void StreamingResponse::cancel() {
     closed = true;
 }
-

--- a/src/main/c/seasocks/StreamingResponse.h
+++ b/src/main/c/seasocks/StreamingResponse.h
@@ -45,7 +45,7 @@ public:
 
     virtual std::shared_ptr<std::istream> getStream() const = 0;
 
-    typedef std::multimap <std::string, std::string> Headers;
+    typedef std::multimap<std::string, std::string> Headers;
     virtual Headers getHeaders() const = 0;
 
     virtual ResponseCode responseCode() const = 0;
@@ -58,4 +58,3 @@ public:
 };
 
 }
-

--- a/src/main/c/seasocks/StringUtil.h
+++ b/src/main/c/seasocks/StringUtil.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -45,11 +45,11 @@ std::vector<std::string> split(const std::string& input, char splitChar);
 
 void replace(std::string& string, const std::string& find, const std::string& replace);
 
-bool caseInsensitiveSame(const std::string &lhs, const std::string &rhs);
+bool caseInsensitiveSame(const std::string& lhs, const std::string& rhs);
 
 std::string webtime(time_t time);
 
 std::string now();
 
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/SynchronousResponse.cpp
+++ b/src/main/c/seasocks/SynchronousResponse.cpp
@@ -54,7 +54,7 @@ void SynchronousResponse::handle(std::shared_ptr<ResponseWriter> writer) {
         writer->header("Expires", now());
     }
 
-    for (auto & header : headers) {
+    for (auto& header : headers) {
         writer->header(header.first, header.second);
     }
 

--- a/src/main/c/seasocks/SynchronousResponse.h
+++ b/src/main/c/seasocks/SynchronousResponse.h
@@ -38,14 +38,14 @@ public:
 
     virtual ResponseCode responseCode() const = 0;
 
-    virtual const char *payload() const = 0;
+    virtual const char* payload() const = 0;
     virtual size_t payloadSize() const = 0;
 
     virtual std::string contentType() const = 0;
 
     virtual bool keepConnectionAlive() const = 0;
 
-    typedef std::multimap <std::string, std::string> Headers;
+    typedef std::multimap<std::string, std::string> Headers;
     virtual Headers getAdditionalHeaders() const = 0;
 };
 

--- a/src/main/c/seasocks/ToString.h
+++ b/src/main/c/seasocks/ToString.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -31,7 +31,7 @@
 
 namespace seasocks {
 
-template<typename T, typename std::enable_if<!std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
+template <typename T, typename std::enable_if<!std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
 std::string toString(const T& obj) {
     std::stringstream str;
     str.imbue(std::locale("C"));
@@ -39,7 +39,7 @@ std::string toString(const T& obj) {
     return str.str();
 }
 
-template<typename T, typename std::enable_if<std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
+template <typename T, typename std::enable_if<std::is_integral<typename std::decay<T>::type>::value, int>::type = 0>
 inline std::string toString(T&& value) {
     return std::to_string(std::forward<T>(value));
 }

--- a/src/main/c/seasocks/WebSocket.h
+++ b/src/main/c/seasocks/WebSocket.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -45,7 +45,9 @@ public:
      * See Server::execute for how to run work on the seasocks
      * thread externally.
      */
-    void send(const std::string& data) { send(data.c_str()); }
+    void send(const std::string& data) {
+        send(data.c_str());
+    }
     /**
      * Send the given binary data. Must be called on the seasocks thread.
      * See Server::execute for how to run work on the seasocks
@@ -73,11 +75,13 @@ public:
         /**
          * Called on the seasocks thread with upon receipt of a full text WebSocket message.
          */
-        virtual void onData(WebSocket*, const char*) {}
+        virtual void onData(WebSocket*, const char*) {
+        }
         /**
          * Called on the seasocks thread with upon receipt of a full binary WebSocket message.
          */
-        virtual void onData(WebSocket*, const uint8_t*, size_t) {}
+        virtual void onData(WebSocket*, const uint8_t*, size_t) {
+        }
         /**
          * Called on the seasocks thread when the socket has been
          */
@@ -86,7 +90,9 @@ public:
          * Choose a protocol before accepting a connection: return < 0 to reject the connection, else return the ordinal
          * in the vector of string protocols.
          */
-        virtual ssize_t chooseProtocol(const std::vector<std::string> &) const { return 0; }
+        virtual ssize_t chooseProtocol(const std::vector<std::string>&) const {
+            return 0;
+        }
     };
 
 protected:
@@ -95,4 +101,4 @@ protected:
     virtual ~WebSocket() = default;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/ZlibContext.cpp
+++ b/src/main/c/seasocks/ZlibContext.cpp
@@ -46,13 +46,12 @@ struct ZlibContext::Impl {
         deflateStream.opaque = Z_NULL;
 
         ret = ::deflateInit2(
-                &deflateStream,
-                Z_DEFAULT_COMPRESSION,
-                Z_DEFLATED,
-                deflateBits * -1,
-                memLevel,
-                Z_DEFAULT_STRATEGY
-        );
+            &deflateStream,
+            Z_DEFAULT_COMPRESSION,
+            Z_DEFLATED,
+            deflateBits * -1,
+            memLevel,
+            Z_DEFAULT_STRATEGY);
 
         if (ret != Z_OK) {
             throw std::runtime_error("error initialising zlib deflater");
@@ -65,9 +64,8 @@ struct ZlibContext::Impl {
         inflateStream.next_in = Z_NULL;
 
         ret = ::inflateInit2(
-                &inflateStream,
-                inflateBits * -1
-        );
+            &inflateStream,
+            inflateBits * -1);
 
         if (ret != Z_OK) {
             ::deflateEnd(&deflateStream);
@@ -78,13 +76,14 @@ struct ZlibContext::Impl {
     }
 
     ~Impl() {
-        if (!streamsInitialised) return;
+        if (!streamsInitialised)
+            return;
         ::deflateEnd(&deflateStream);
         ::inflateEnd(&inflateStream);
     }
 
-    void deflate(const uint8_t *input, size_t inputLen, std::vector<uint8_t> &output) {
-        deflateStream.next_in = (unsigned char *) input;
+    void deflate(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output) {
+        deflateStream.next_in = (unsigned char*) input;
         deflateStream.avail_in = inputLen;
 
         do {
@@ -100,7 +99,7 @@ struct ZlibContext::Impl {
         output.resize(output.size() - 4);
     }
 
-    bool inflate(std::vector<uint8_t> &input, std::vector<uint8_t> &output, int &zlibError) {
+    bool inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& output, int& zlibError) {
         // Append 4 octets prior to decompression (see RFC 7692, section 7.2.2)
         uint8_t tail_end[4] = {0x00, 0x00, 0xff, 0xff};
         input.insert(input.end(), tail_end, tail_end + 4);
@@ -134,11 +133,11 @@ void ZlibContext::initialise(int deflateBits, int inflateBits, int memLevel) {
     _impl = std::make_unique<Impl>(deflateBits, inflateBits, memLevel);
 }
 
-void ZlibContext::deflate(const uint8_t *input, size_t inputLen, std::vector<uint8_t> &output) {
+void ZlibContext::deflate(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output) {
     return _impl->deflate(input, inputLen, output);
 }
 
-bool ZlibContext::inflate(std::vector<uint8_t> &input, std::vector<uint8_t> &output, int &zlibError) {
+bool ZlibContext::inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& output, int& zlibError) {
     return _impl->inflate(input, output, zlibError);
 }
 

--- a/src/main/c/seasocks/ZlibContext.h
+++ b/src/main/c/seasocks/ZlibContext.h
@@ -14,7 +14,7 @@ public:
 
     ZlibContext();
     ~ZlibContext();
-    void initialise(int deflateBits=15, int inflateBits=15, int memLevel=6);
+    void initialise(int deflateBits = 15, int inflateBits = 15, int memLevel = 6);
 
     void deflate(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output);
 
@@ -26,4 +26,4 @@ private:
     std::unique_ptr<Impl> _impl;
 };
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/ZlibContextDisabled.cpp
+++ b/src/main/c/seasocks/ZlibContextDisabled.cpp
@@ -42,11 +42,11 @@ void ZlibContext::initialise(int, int, int) {
     throw std::runtime_error("Not compiled with zlib support");
 }
 
-void ZlibContext::deflate(const uint8_t *, size_t, std::vector<uint8_t> &) {
+void ZlibContext::deflate(const uint8_t*, size_t, std::vector<uint8_t>&) {
     throw std::runtime_error("Not compiled with zlib support");
 }
 
-bool ZlibContext::inflate(std::vector<uint8_t> &, std::vector<uint8_t> &, int &) {
+bool ZlibContext::inflate(std::vector<uint8_t>&, std::vector<uint8_t>&, int&) {
     throw std::runtime_error("Not compiled with zlib support");
 }
 

--- a/src/main/c/seasocks/util/CrackedUri.h
+++ b/src/main/c/seasocks/util/CrackedUri.h
@@ -38,8 +38,12 @@ class CrackedUri {
 public:
     explicit CrackedUri(const std::string& uri);
 
-    const std::vector<std::string>& path() const { return _path; }
-    const std::unordered_multimap<std::string, std::string> queryParams() const { return _queryParams; }
+    const std::vector<std::string>& path() const {
+        return _path;
+    }
+    const std::unordered_multimap<std::string, std::string> queryParams() const {
+        return _queryParams;
+    }
 
     bool hasParam(const std::string& param) const;
 

--- a/src/main/c/seasocks/util/CrackedUriPageHandler.h
+++ b/src/main/c/seasocks/util/CrackedUriPageHandler.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/seasocks/util/Html.h
+++ b/src/main/c/seasocks/util/Html.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -47,30 +47,33 @@ class Element {
     void append() {
     }
 
-    template<typename T, typename... Args>
-    void append(const T& t, Args&& ...args) {
+    template <typename T, typename... Args>
+    void append(const T& t, Args&&... args) {
         operator<<(t);
         append(std::forward<Args>(args)...);
     }
 
-    Element() : _isTextNode(true), _needsClose(false) {}
+    Element()
+            : _isTextNode(true), _needsClose(false) {
+    }
+
 public:
-    template<typename... Args>
-    Element(const std::string& name, bool needsClose, Args&&... args) :
-        _isTextNode(false),
-        _needsClose(needsClose),
-        _nameOrText(name) {
+    template <typename... Args>
+    Element(const std::string& name, bool needsClose, Args&&... args)
+            : _isTextNode(false),
+              _needsClose(needsClose),
+              _nameOrText(name) {
         append(std::forward<Args>(args)...);
     }
 
-    template<typename T>
+    template <typename T>
     static Element textElement(const T& text) {
         Element e;
         e._nameOrText = toString(text);
         return e;
     }
 
-    template<typename T>
+    template <typename T>
     Element& addAttribute(const char* attr, const T& value) {
         _attributes += std::string(" ") + attr + "=\"" + toString(value) + "\"";
         return *this;
@@ -100,38 +103,38 @@ public:
         return addAttribute("id", id);
     }
 
-    Element& operator <<(const char* child) {
+    Element& operator<<(const char* child) {
         _children.push_back(textElement(child));
         return *this;
     }
 
-    Element& operator <<(const std::string& child) {
+    Element& operator<<(const std::string& child) {
         _children.push_back(textElement(child));
         return *this;
     }
 
-    Element& operator <<(const Element& child) {
+    Element& operator<<(const Element& child) {
         _children.push_back(child);
         return *this;
     }
 
-    template<class T>
+    template <class T>
     typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value, Element&>::type
-    operator <<(const T& child) {
+    operator<<(const T& child) {
         _children.push_back(textElement(child));
         return *this;
     }
 
-    friend std::ostream& operator << (std::ostream& os, const Element& elem) {
+    friend std::ostream& operator<<(std::ostream& os, const Element& elem) {
         if (elem._isTextNode) {
             os << elem._nameOrText;
-            for (const auto & it : elem._children) {
+            for (const auto& it : elem._children) {
                 os << it;
             }
             return os;
         }
         os << "<" << elem._nameOrText << elem._attributes << ">";
-        for (const auto & it : elem._children) {
+        for (const auto& it : elem._children) {
             os << it;
         }
         if (elem._needsClose) {
@@ -140,7 +143,7 @@ public:
         return os;
     }
 
-    template<typename C, typename F>
+    template <typename C, typename F>
     Element& addAll(const C& container, F functor) {
         for (auto it = container.cbegin(); it != container.cend(); ++it) {
             operator<<(functor(*it));
@@ -155,7 +158,11 @@ public:
     }
 };
 
-#define HTMLELEM(XX) template<typename... Args> inline Element XX(Args&&... args) { return Element(#XX, true, std::forward<Args>(args)...); }
+#define HTMLELEM(XX)                                            \
+    template <typename... Args>                                 \
+    inline Element XX(Args&&... args) {                         \
+        return Element(#XX, true, std::forward<Args>(args)...); \
+    }
 HTMLELEM(html)
 HTMLELEM(head)
 HTMLELEM(title)
@@ -180,27 +187,40 @@ HTMLELEM(label)
 HTMLELEM(button)
 #undef HTMLELEM
 
-inline Element empty() { return Element::textElement(""); }
+inline Element empty() {
+    return Element::textElement("");
+}
 
-template<typename T>
-inline Element text(const T& t) { return Element::textElement(t); }
+template <typename T>
+inline Element text(const T& t) {
+    return Element::textElement(t);
+}
 
-inline Element img(const std::string& src) { return Element("img", false).addAttribute("src", src); }
+inline Element img(const std::string& src) {
+    return Element("img", false).addAttribute("src", src);
+}
 
-inline Element checkbox() { return Element("input", false).addAttribute("type", "checkbox"); }
+inline Element checkbox() {
+    return Element("input", false).addAttribute("type", "checkbox");
+}
 
-inline Element externalScript(const std::string& src) { return Element("script", true).addAttribute("src", src).addAttribute("type", "text/javascript"); }
+inline Element externalScript(const std::string& src) {
+    return Element("script", true).addAttribute("src", src).addAttribute("type", "text/javascript");
+}
 
-inline Element inlineScript(const std::string& script) { return Element("script", true, script).addAttribute("type", "text/javascript"); }
+inline Element inlineScript(const std::string& script) {
+    return Element("script", true, script).addAttribute("type", "text/javascript");
+}
 
 inline Element link(const std::string& href, const std::string& rel) {
     return Element("link", false).addAttribute("href", href).addAttribute("rel", rel);
 }
 
-template<typename...Args> inline Element a(const std::string& href, Args&&... args) {
+template <typename... Args>
+inline Element a(const std::string& href, Args&&... args) {
     return Element("a", true, std::forward<Args>(args)...).addAttribute("href", href);
 }
 
-}  // namespace html
+} // namespace html
 
-}  // namespace seasocks
+} // namespace seasocks

--- a/src/main/c/seasocks/util/Json.h
+++ b/src/main/c/seasocks/util/Json.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -38,7 +38,8 @@ namespace seasocks {
 
 ///////////////////////////////////
 
-inline void jsonToStream(std::ostream& /*str*/) {}
+inline void jsonToStream(std::ostream& /*str*/) {
+}
 
 void jsonToStream(std::ostream& str, const char* t);
 
@@ -48,54 +49,52 @@ inline void jsonToStream(std::ostream& str, const std::string& t) {
     jsonToStream(str, t.c_str());
 }
 
-template<typename O>
+template <typename O>
 class is_jsonable {
-    template<typename OO>
+    template <typename OO>
     static auto test(int)
-    -> decltype(&OO::jsonToStream, std::true_type());
+        -> decltype(&OO::jsonToStream, std::true_type());
 
-    template<typename>
+    template <typename>
     static auto test(...) -> std::false_type;
 
 public:
     static constexpr bool value = decltype(test<O>(0))::value;
 };
 
-template<typename T>
+template <typename T>
 class is_streamable {
-    template<typename TT>
+    template <typename TT>
     static auto test(int)
-    -> decltype(std::declval<std::ostream&>() << std::declval<TT>(), std::true_type());
+        -> decltype(std::declval<std::ostream&>() << std::declval<TT>(), std::true_type());
 
-    template<typename>
+    template <typename>
     static auto test(...) -> std::false_type;
 
 public:
     static constexpr bool value = decltype(test<T>(0))::value;
 };
 
-template<typename T>
+template <typename T>
 typename std::enable_if<std::is_fundamental<T>::value, void>::type
 jsonToStream(std::ostream& str, const T& t) {
     str << t;
 }
 
-template<typename T>
+template <typename T>
 typename std::enable_if<is_jsonable<T>::value, void>::type
 jsonToStream(std::ostream& str, const T& t) {
     t.jsonToStream(str);
 }
 
-template<typename T>
+template <typename T>
 typename std::enable_if<
-    !std::is_fundamental<T>::value
-    && is_streamable<T>::value
-    && !is_jsonable<T>::value, void>::type
+    !std::is_fundamental<T>::value && is_streamable<T>::value && !is_jsonable<T>::value, void>::type
 jsonToStream(std::ostream& str, const T& t) {
     str << '"' << t << '"';
 }
 
-template<typename T, typename ... Args>
+template <typename T, typename... Args>
 void jsonToStream(std::ostream& str, const T& t, Args&&... args) {
     static_assert(sizeof...(Args) > 0, "Cannot stream an object with no jsonToStream or operator<< method.");
     jsonToStream(str, t);
@@ -105,27 +104,28 @@ void jsonToStream(std::ostream& str, const T& t, Args&&... args) {
 
 ///////////////////////////////////
 
-inline void jsonKeyPairToStream(std::ostream& /*str*/) {}
+inline void jsonKeyPairToStream(std::ostream& /*str*/) {
+}
 
-template<typename T>
+template <typename T>
 void jsonKeyPairToStream(std::ostream& str, const char* key, const T& value) {
     jsonToStream(str, key);
     str << ":";
     jsonToStream(str, value);
 }
 
-template<typename T>
+template <typename T>
 void jsonKeyPairToStream(std::ostream& str, const std::string& key, const T& value) {
     jsonKeyPairToStream(str, key.c_str(), value);
 }
 
-template<typename T>
+template <typename T>
 void jsonKeyPairToStream(std::ostream&, const T&) {
-    static_assert(!std::is_same<T, T>::value,  // To make the assertion depend on T
-            "Requires an even number of parameters. If you're trying to build a map from an existing std::map or similar, use makeMapFromContainer");
+    static_assert(!std::is_same<T, T>::value, // To make the assertion depend on T
+                  "Requires an even number of parameters. If you're trying to build a map from an existing std::map or similar, use makeMapFromContainer");
 }
 
-template<typename K, typename V, typename... Args>
+template <typename K, typename V, typename... Args>
 void jsonKeyPairToStream(std::ostream& str, const K& key, const V& value, Args&&... args) {
     jsonKeyPairToStream(str, key, value);
     str << ",";
@@ -134,9 +134,13 @@ void jsonKeyPairToStream(std::ostream& str, const K& key, const V& value, Args&&
 
 struct JsonnedString : std::string {
     JsonnedString() = default;
-    JsonnedString(const std::string& s) : std::string(s) {}
-    JsonnedString(const std::stringstream& str) : std::string(str.str()) {}
-    void jsonToStream(std::ostream &o) const {
+    JsonnedString(const std::string& s)
+            : std::string(s) {
+    }
+    JsonnedString(const std::stringstream& str)
+            : std::string(str.str()) {
+    }
+    void jsonToStream(std::ostream& o) const {
         o << *this;
     }
 };
@@ -145,12 +149,14 @@ static_assert(is_jsonable<JsonnedString>::value, "Internal stream problem");
 
 struct EpochTimeAsLocal {
     time_t t;
-    EpochTimeAsLocal(time_t time) : t(time) {}
-    void jsonToStream(std::ostream &o) const;
+    EpochTimeAsLocal(time_t time)
+            : t(time) {
+    }
+    void jsonToStream(std::ostream& o) const;
 };
 static_assert(is_jsonable<EpochTimeAsLocal>::value, "Internal stream problem");
 
-template<typename... Args>
+template <typename... Args>
 JsonnedString makeMap(Args&&... args) {
     std::stringstream str;
     str << '{';
@@ -159,13 +165,14 @@ JsonnedString makeMap(Args&&... args) {
     return JsonnedString(str);
 }
 
-template<typename T>
+template <typename T>
 JsonnedString makeMapFromContainer(const T& m) {
     std::stringstream str;
     str << "{";
     bool first = true;
-    for (const auto &it : m) {
-        if (!first) str << ",";
+    for (const auto& it : m) {
+        if (!first)
+            str << ",";
         first = false;
         jsonKeyPairToStream(str, it.first, it.second);
     }
@@ -173,7 +180,7 @@ JsonnedString makeMapFromContainer(const T& m) {
     return JsonnedString(str);
 }
 
-template<typename ... Args>
+template <typename... Args>
 JsonnedString makeArray(Args&&... args) {
     std::stringstream str;
     str << '[';
@@ -182,12 +189,12 @@ JsonnedString makeArray(Args&&... args) {
     return JsonnedString(str);
 }
 
-template<typename T>
-JsonnedString makeArrayFromContainer(const T &list) {
+template <typename T>
+JsonnedString makeArrayFromContainer(const T& list) {
     std::stringstream str;
     str << '[';
     bool first = true;
-    for (const auto &s : list) {
+    for (const auto& s : list) {
         if (!first) {
             str << ',';
         }
@@ -198,12 +205,12 @@ JsonnedString makeArrayFromContainer(const T &list) {
     return JsonnedString(str);
 }
 
-template<typename T>
-JsonnedString makeArray(const std::initializer_list<T> &list) {
+template <typename T>
+JsonnedString makeArray(const std::initializer_list<T>& list) {
     std::stringstream str;
     str << '[';
     bool first = true;
-    for (const auto &s : list) {
+    for (const auto& s : list) {
         if (!first) {
             str << ',';
         }
@@ -214,7 +221,7 @@ JsonnedString makeArray(const std::initializer_list<T> &list) {
     return JsonnedString(str);
 }
 
-template<typename ... Args>
+template <typename... Args>
 JsonnedString makeExecString(const char* function, Args&&... args) {
     std::stringstream str;
     str << function << '(';
@@ -223,8 +230,8 @@ JsonnedString makeExecString(const char* function, Args&&... args) {
     return JsonnedString(str);
 }
 
-template<typename T>
-JsonnedString to_json(const T &obj) {
+template <typename T>
+JsonnedString to_json(const T& obj) {
     std::stringstream str;
     jsonToStream(str, obj);
     return str.str();

--- a/src/main/c/seasocks/util/PathHandler.h
+++ b/src/main/c/seasocks/util/PathHandler.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
@@ -45,24 +45,30 @@ class PathHandler : public CrackedUriPageHandler {
     std::vector<CrackedUriPageHandler::Ptr> _handlers;
 
 public:
-    PathHandler(const std::string &path) : _path(path),_handlers() {}
-    template<typename... Args>
-    PathHandler(const std::string &path, Args&&... args) : _path(path),_handlers() {
+    PathHandler(const std::string& path)
+            : _path(path), _handlers() {
+    }
+    template <typename... Args>
+    PathHandler(const std::string& path, Args&&... args)
+            : _path(path), _handlers() {
         addMany(std::forward<Args>(args)...);
     }
 
     CrackedUriPageHandler::Ptr add(const CrackedUriPageHandler::Ptr& handler);
 
-    void addMany() {}
-    void addMany(const CrackedUriPageHandler::Ptr& handler) { add(handler); }
-    template<typename... Rest>
+    void addMany() {
+    }
+    void addMany(const CrackedUriPageHandler::Ptr& handler) {
+        add(handler);
+    }
+    template <typename... Rest>
     void addMany(const CrackedUriPageHandler::Ptr& handler, Rest&&... rest) {
         add(handler);
         addMany(std::forward<Rest>(rest)...);
     }
 
     virtual std::shared_ptr<Response> handle(
-            const CrackedUri& uri, const Request& request) override;
+        const CrackedUri& uri, const Request& request) override;
 };
 
 }

--- a/src/main/c/seasocks/util/RootPageHandler.h
+++ b/src/main/c/seasocks/util/RootPageHandler.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once

--- a/src/main/c/seasocks/util/StaticResponseHandler.h
+++ b/src/main/c/seasocks/util/StaticResponseHandler.h
@@ -1,26 +1,26 @@
 // Copyright (c) 2013-2017, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// Redistributions of source code must retain the above copyright notice, this 
+//
+// Redistributions of source code must retain the above copyright notice, this
 // list of conditions and the following disclaimer.
-// 
-// Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <seasocks/util/CrackedUriPageHandler.h>
@@ -37,11 +37,12 @@ class StaticResponseHandler : public CrackedUriPageHandler {
 
 public:
     StaticResponseHandler(const std::string& path, std::shared_ptr<Response> response)
-    : _path(path), _response(response) {}
+            : _path(path), _response(response) {
+    }
 
     virtual std::shared_ptr<Response> handle(
-            const CrackedUri& uri,
-            const Request&) override {
+        const CrackedUri& uri,
+        const Request&) override {
         if (uri.path().size() != 1 || uri.path()[0] != _path)
             return Response::unhandled();
         return _response;

--- a/src/main/c/sha1/sha1.cpp
+++ b/src/main/c/sha1/sha1.cpp
@@ -81,8 +81,7 @@
  *  Comments:
  *
  */
-SHA1::SHA1()
-{
+SHA1::SHA1() {
     Reset();
 }
 
@@ -102,20 +101,19 @@ SHA1::SHA1()
  *  Comments:
  *
  */
-void SHA1::Reset()
-{
-    Length_Low          = 0;
-    Length_High         = 0;
+void SHA1::Reset() {
+    Length_Low = 0;
+    Length_High = 0;
     Message_Block_Index = 0;
 
-    H[0]        = 0x67452301;
-    H[1]        = 0xEFCDAB89;
-    H[2]        = 0x98BADCFE;
-    H[3]        = 0x10325476;
-    H[4]        = 0xC3D2E1F0;
+    H[0] = 0x67452301;
+    H[1] = 0xEFCDAB89;
+    H[2] = 0x98BADCFE;
+    H[3] = 0x10325476;
+    H[4] = 0xC3D2E1F0;
 
-    Computed    = false;
-    Corrupted   = false;
+    Computed = false;
+    Corrupted = false;
 }
 
 /*
@@ -136,23 +134,19 @@ void SHA1::Reset()
  *  Comments:
  *
  */
-bool SHA1::Result(unsigned *message_digest_array)
-{
-    int i;                                  // Counter
+bool SHA1::Result(unsigned* message_digest_array) {
+    int i; // Counter
 
-    if (Corrupted)
-    {
+    if (Corrupted) {
         return false;
     }
 
-    if (!Computed)
-    {
+    if (!Computed) {
         PadMessage();
         Computed = true;
     }
 
-    for(i = 0; i < 5; i++)
-    {
+    for (i = 0; i < 5; i++) {
         message_digest_array[i] = H[i];
     }
 
@@ -177,38 +171,31 @@ bool SHA1::Result(unsigned *message_digest_array)
  *  Comments:
  *
  */
-void SHA1::Input(   const unsigned char *message_array,
-                    unsigned            length)
-{
-    if (!length)
-    {
+void SHA1::Input(const unsigned char* message_array,
+                 unsigned length) {
+    if (!length) {
         return;
     }
 
-    if (Computed || Corrupted)
-    {
+    if (Computed || Corrupted) {
         Corrupted = true;
         return;
     }
 
-    while(length-- && !Corrupted)
-    {
+    while (length-- && !Corrupted) {
         Message_Block[Message_Block_Index++] = (*message_array & 0xFF);
 
         Length_Low += 8;
-        Length_Low &= 0xFFFFFFFF;               // Force it to 32 bits
-        if (Length_Low == 0)
-        {
+        Length_Low &= 0xFFFFFFFF; // Force it to 32 bits
+        if (Length_Low == 0) {
             Length_High++;
-            Length_High &= 0xFFFFFFFF;          // Force it to 32 bits
-            if (Length_High == 0)
-            {
-                Corrupted = true;               // Message is too long
+            Length_High &= 0xFFFFFFFF; // Force it to 32 bits
+            if (Length_High == 0) {
+                Corrupted = true; // Message is too long
             }
         }
 
-        if (Message_Block_Index == 64)
-        {
+        if (Message_Block_Index == 64) {
             ProcessMessageBlock();
         }
 
@@ -236,10 +223,9 @@ void SHA1::Input(   const unsigned char *message_array,
  *  Comments:
  *
  */
-void SHA1::Input(   const char  *message_array,
-                    unsigned    length)
-{
-    Input((unsigned char *) message_array, length);
+void SHA1::Input(const char* message_array,
+                 unsigned length) {
+    Input((unsigned char*) message_array, length);
 }
 
 /*
@@ -258,8 +244,7 @@ void SHA1::Input(   const char  *message_array,
  *  Comments:
  *
  */
-void SHA1::Input(unsigned char message_element)
-{
+void SHA1::Input(unsigned char message_element) {
     Input(&message_element, 1);
 }
 
@@ -279,9 +264,8 @@ void SHA1::Input(unsigned char message_element)
  *  Comments:
  *
  */
-void SHA1::Input(char message_element)
-{
-    Input((unsigned char *) &message_element, 1);
+void SHA1::Input(char message_element) {
+    Input((unsigned char*) &message_element, 1);
 }
 
 /*
@@ -302,12 +286,10 @@ void SHA1::Input(char message_element)
  *      Each character is assumed to hold 8 bits of information.
  *
  */
-SHA1& SHA1::operator<<(const char *message_array)
-{
-    const char *p = message_array;
+SHA1& SHA1::operator<<(const char* message_array) {
+    const char* p = message_array;
 
-    while(*p)
-    {
+    while (*p) {
         Input(*p);
         p++;
     }
@@ -333,12 +315,10 @@ SHA1& SHA1::operator<<(const char *message_array)
  *      Each character is assumed to hold 8 bits of information.
  *
  */
-SHA1& SHA1::operator<<(const unsigned char *message_array)
-{
-    const unsigned char *p = message_array;
+SHA1& SHA1::operator<<(const unsigned char* message_array) {
+    const unsigned char* p = message_array;
 
-    while(*p)
-    {
+    while (*p) {
         Input(*p);
         p++;
     }
@@ -363,9 +343,8 @@ SHA1& SHA1::operator<<(const unsigned char *message_array)
  *      The character is assumed to hold 8 bits of information.
  *
  */
-SHA1& SHA1::operator<<(const char message_element)
-{
-    Input((unsigned char *) &message_element, 1);
+SHA1& SHA1::operator<<(const char message_element) {
+    Input((unsigned char*) &message_element, 1);
 
     return *this;
 }
@@ -387,8 +366,7 @@ SHA1& SHA1::operator<<(const char message_element)
  *      The character is assumed to hold 8 bits of information.
  *
  */
-SHA1& SHA1::operator<<(const unsigned char message_element)
-{
+SHA1& SHA1::operator<<(const unsigned char message_element) {
     Input(&message_element, 1);
 
     return *this;
@@ -413,33 +391,29 @@ SHA1& SHA1::operator<<(const unsigned char message_element)
  *      in the publication.
  *
  */
-void SHA1::ProcessMessageBlock()
-{
-    const unsigned K[] =    {               // Constants defined for SHA-1
-                                0x5A827999,
-                                0x6ED9EBA1,
-                                0x8F1BBCDC,
-                                0xCA62C1D6
-                            };
-    int         t;                          // Loop counter
-    unsigned    temp;                       // Temporary word value
-    unsigned    W[80];                      // Word sequence
-    unsigned    A, B, C, D, E;              // Word buffers
+void SHA1::ProcessMessageBlock() {
+    const unsigned K[] = {// Constants defined for SHA-1
+                          0x5A827999,
+                          0x6ED9EBA1,
+                          0x8F1BBCDC,
+                          0xCA62C1D6};
+    int t;                  // Loop counter
+    unsigned temp;          // Temporary word value
+    unsigned W[80];         // Word sequence
+    unsigned A, B, C, D, E; // Word buffers
 
     /*
      *  Initialize the first 16 words in the array W
      */
-    for(t = 0; t < 16; t++)
-    {
+    for (t = 0; t < 16; t++) {
         W[t] = ((unsigned) Message_Block[t * 4]) << 24;
         W[t] |= ((unsigned) Message_Block[t * 4 + 1]) << 16;
         W[t] |= ((unsigned) Message_Block[t * 4 + 2]) << 8;
         W[t] |= ((unsigned) Message_Block[t * 4 + 3]);
     }
 
-    for(t = 16; t < 80; t++)
-    {
-       W[t] = CircularShift(1,W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16]);
+    for (t = 16; t < 80; t++) {
+        W[t] = CircularShift(1, W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16]);
     }
 
     A = H[0];
@@ -448,47 +422,43 @@ void SHA1::ProcessMessageBlock()
     D = H[3];
     E = H[4];
 
-    for(t = 0; t < 20; t++)
-    {
-        temp = CircularShift(5,A) + ((B & C) | ((~B) & D)) + E + W[t] + K[0];
+    for (t = 0; t < 20; t++) {
+        temp = CircularShift(5, A) + ((B & C) | ((~B) & D)) + E + W[t] + K[0];
         temp &= 0xFFFFFFFF;
         E = D;
         D = C;
-        C = CircularShift(30,B);
+        C = CircularShift(30, B);
         B = A;
         A = temp;
     }
 
-    for(t = 20; t < 40; t++)
-    {
-        temp = CircularShift(5,A) + (B ^ C ^ D) + E + W[t] + K[1];
+    for (t = 20; t < 40; t++) {
+        temp = CircularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[1];
         temp &= 0xFFFFFFFF;
         E = D;
         D = C;
-        C = CircularShift(30,B);
+        C = CircularShift(30, B);
         B = A;
         A = temp;
     }
 
-    for(t = 40; t < 60; t++)
-    {
-        temp = CircularShift(5,A) +
+    for (t = 40; t < 60; t++) {
+        temp = CircularShift(5, A) +
                ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
         temp &= 0xFFFFFFFF;
         E = D;
         D = C;
-        C = CircularShift(30,B);
+        C = CircularShift(30, B);
         B = A;
         A = temp;
     }
 
-    for(t = 60; t < 80; t++)
-    {
-        temp = CircularShift(5,A) + (B ^ C ^ D) + E + W[t] + K[3];
+    for (t = 60; t < 80; t++) {
+        temp = CircularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[3];
         temp &= 0xFFFFFFFF;
         E = D;
         D = C;
-        C = CircularShift(30,B);
+        C = CircularShift(30, B);
         B = A;
         A = temp;
     }
@@ -523,36 +493,28 @@ void SHA1::ProcessMessageBlock()
  *  Comments:
  *
  */
-void SHA1::PadMessage()
-{
+void SHA1::PadMessage() {
     /*
      *  Check to see if the current message block is too small to hold
      *  the initial padding bits and length.  If so, we will pad the
      *  block, process it, and then continue padding into a second block.
      */
-    if (Message_Block_Index > 55)
-    {
+    if (Message_Block_Index > 55) {
         Message_Block[Message_Block_Index++] = 0x80;
-        while(Message_Block_Index < 64)
-        {
+        while (Message_Block_Index < 64) {
             Message_Block[Message_Block_Index++] = 0;
         }
 
         ProcessMessageBlock();
 
-        while(Message_Block_Index < 56)
-        {
+        while (Message_Block_Index < 56) {
             Message_Block[Message_Block_Index++] = 0;
         }
-    }
-    else
-    {
+    } else {
         Message_Block[Message_Block_Index++] = 0x80;
-        while(Message_Block_Index < 56)
-        {
+        while (Message_Block_Index < 56) {
             Message_Block[Message_Block_Index++] = 0;
         }
-
     }
 
     /*
@@ -561,11 +523,11 @@ void SHA1::PadMessage()
     Message_Block[56] = (Length_High >> 24) & 0xFF;
     Message_Block[57] = (Length_High >> 16) & 0xFF;
     Message_Block[58] = (Length_High >> 8) & 0xFF;
-    Message_Block[59] = (Length_High) & 0xFF;
+    Message_Block[59] = (Length_High) &0xFF;
     Message_Block[60] = (Length_Low >> 24) & 0xFF;
     Message_Block[61] = (Length_Low >> 16) & 0xFF;
     Message_Block[62] = (Length_Low >> 8) & 0xFF;
-    Message_Block[63] = (Length_Low) & 0xFF;
+    Message_Block[63] = (Length_Low) &0xFF;
 
     ProcessMessageBlock();
 }
@@ -589,7 +551,6 @@ void SHA1::PadMessage()
  *  Comments:
  *
  */
-unsigned SHA1::CircularShift(int bits, unsigned word)
-{
-    return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32-bits));
+unsigned SHA1::CircularShift(int bits, unsigned word) {
+    return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
 }

--- a/src/main/c/sha1/sha1.h
+++ b/src/main/c/sha1/sha1.h
@@ -50,64 +50,60 @@
 #ifndef _SHA1_H_
 #define _SHA1_H_
 
-class SHA1
-{
+class SHA1 {
 
-    public:
+public:
+    SHA1();
 
-        SHA1();
-
-        /*
+    /*
          *  Re-initialize the class
          */
-        void Reset();
+    void Reset();
 
-        /*
+    /*
          *  Returns the message digest
          */
-        bool Result(unsigned *message_digest_array);
+    bool Result(unsigned* message_digest_array);
 
-        /*
+    /*
          *  Provide input to SHA1
          */
-        void Input( const unsigned char *message_array,
-                    unsigned            length);
-        void Input( const char  *message_array,
-                    unsigned    length);
-        void Input(unsigned char message_element);
-        void Input(char message_element);
-        SHA1& operator<<(const char *message_array);
-        SHA1& operator<<(const unsigned char *message_array);
-        SHA1& operator<<(const char message_element);
-        SHA1& operator<<(const unsigned char message_element);
+    void Input(const unsigned char* message_array,
+               unsigned length);
+    void Input(const char* message_array,
+               unsigned length);
+    void Input(unsigned char message_element);
+    void Input(char message_element);
+    SHA1& operator<<(const char* message_array);
+    SHA1& operator<<(const unsigned char* message_array);
+    SHA1& operator<<(const char message_element);
+    SHA1& operator<<(const unsigned char message_element);
 
-    private:
-
-        /*
+private:
+    /*
          *  Process the next 512 bits of the message
          */
-        void ProcessMessageBlock();
+    void ProcessMessageBlock();
 
-        /*
+    /*
          *  Pads the current message block to 512 bits
          */
-        void PadMessage();
+    void PadMessage();
 
-        /*
+    /*
          *  Performs a circular left shift operation
          */
-        inline unsigned CircularShift(int bits, unsigned word);
+    inline unsigned CircularShift(int bits, unsigned word);
 
-        unsigned H[5];                      // Message digest buffers
+    unsigned H[5]; // Message digest buffers
 
-        unsigned Length_Low;                // Message length in bits
-        unsigned Length_High;               // Message length in bits
+    unsigned Length_Low;  // Message length in bits
+    unsigned Length_High; // Message length in bits
 
-        unsigned char Message_Block[64];    // 512-bit message blocks
-        int Message_Block_Index;            // Index into message block array
+    unsigned char Message_Block[64]; // 512-bit message blocks
+    int Message_Block_Index;         // Index into message block array
 
-        bool Computed;                      // Is the digest computed?
-        bool Corrupted;                     // Is the message digest corruped?
-
+    bool Computed;  // Is the digest computed?
+    bool Corrupted; // Is the message digest corruped?
 };
 #endif

--- a/src/main/c/util/CrackedUri.cpp
+++ b/src/main/c/util/CrackedUri.cpp
@@ -30,10 +30,10 @@
 #include <sstream>
 #include <stdexcept>
 
-#define THROW(stuff) \
-    do {\
-        std::ostringstream err; \
-        err << stuff; \
+#define THROW(stuff)                         \
+    do {                                     \
+        std::ostringstream err;              \
+        err << stuff;                        \
         throw std::runtime_error(err.str()); \
     } while (0);
 
@@ -87,8 +87,9 @@ CrackedUri::CrackedUri(const std::string& uri) {
     std::transform(_path.begin(), _path.end(), _path.begin(), unescape);
 
     auto splitRemainder = split(remainder, '&');
-    for (const auto & iter : splitRemainder) {
-        if (iter.empty()) continue;
+    for (const auto& iter : splitRemainder) {
+        if (iter.empty())
+            continue;
         auto split = seasocks::split(iter, '=');
         std::transform(split.begin(), split.end(), split.begin(), unescape);
         if (split.size() == 1) {

--- a/src/main/c/util/Json.cpp
+++ b/src/main/c/util/Json.cpp
@@ -33,23 +33,34 @@ void jsonToStream(std::ostream& str, const char* t) {
     str << '"';
     for (; *t; ++t) {
         switch (*t) {
-        default:
-            if (static_cast<unsigned char>(*t) >= 32) {
+            default:
+                if (static_cast<unsigned char>(*t) >= 32) {
+                    str << *t;
+                } else {
+                    str << "\\u" << std::setw(4)
+                        << std::setfill('0') << std::hex << static_cast<int>(*t);
+                }
+                break;
+            case 8:
+                str << "\\b";
+                break;
+            case 9:
+                str << "\\t";
+                break;
+            case 10:
+                str << "\\n";
+                break;
+            case 12:
+                str << "\\f";
+                break;
+            case 13:
+                str << "\\r";
+                break;
+            case '"':
+            case '\\':
+                str << '\\';
                 str << *t;
-            } else {
-                str << "\\u" << std::setw(4)
-                    << std::setfill('0') << std::hex << static_cast<int>(*t);
-            }
-            break;
-        case 8: str << "\\b"; break;
-        case 9: str << "\\t"; break;
-        case 10: str << "\\n"; break;
-        case 12: str << "\\f"; break;
-        case 13: str << "\\r"; break;
-        case '"': case '\\':
-            str << '\\';
-            str << *t;
-            break;
+                break;
         }
     }
     str << '"';
@@ -59,7 +70,7 @@ void jsonToStream(std::ostream& str, bool b) {
     str << (b ? "true" : "false");
 }
 
-void EpochTimeAsLocal::jsonToStream(std::ostream &o) const {
+void EpochTimeAsLocal::jsonToStream(std::ostream& o) const {
     o << "new Date(" << t * 1000 << ").toLocaleString()";
 }
 

--- a/src/main/c/util/PathHandler.cpp
+++ b/src/main/c/util/PathHandler.cpp
@@ -37,15 +37,15 @@ CrackedUriPageHandler::Ptr PathHandler::add(const CrackedUriPageHandler::Ptr& ha
 }
 
 std::shared_ptr<Response> PathHandler::handle(
-        const CrackedUri& uri, const Request& request) {
-    const auto &path = uri.path();
+    const CrackedUri& uri, const Request& request) {
+    const auto& path = uri.path();
     if (path.empty() || path[0] != _path) {
         return Response::unhandled();
     }
 
     auto shiftedUri = uri.shift();
 
-    for (const auto &it : _handlers) {
+    for (const auto& it : _handlers) {
         auto response = it->handle(shiftedUri, request);
         if (response != Response::unhandled()) {
             return response;

--- a/src/main/c/util/RootPageHandler.cpp
+++ b/src/main/c/util/RootPageHandler.cpp
@@ -42,7 +42,7 @@ CrackedUriPageHandler::Ptr RootPageHandler::add(const CrackedUriPageHandler::Ptr
 
 std::shared_ptr<Response> RootPageHandler::handle(const Request& request) {
     CrackedUri uri(request.getRequestUri());
-    for (const auto &it : _handlers) {
+    for (const auto& it : _handlers) {
         auto response = it->handle(uri, request);
         if (response != Response::unhandled()) {
             return response;

--- a/src/test/c/ConnectionTests.cpp
+++ b/src/test/c/ConnectionTests.cpp
@@ -39,8 +39,8 @@ using namespace seasocks;
 class TestHandler : public WebSocket::Handler {
 public:
     int _stage;
-    TestHandler() :
-        _stage(0) {
+    TestHandler()
+            : _stage(0) {
     }
     ~TestHandler() {
         if (_stage != 2) {
@@ -74,7 +74,7 @@ TEST_CASE("Connection tests", "[ConnectionTests]") {
 
     SECTION("should break hixie messages apart in same buffer") {
         connection.setHandler(std::make_shared<TestHandler>());
-        uint8_t foo[] = { 0x00, 'a', 0xff, 0x00, 'b', 0xff };
+        uint8_t foo[] = {0x00, 'a', 0xff, 0x00, 'b', 0xff};
         connection.getInputBuffer().assign(&foo[0], &foo[sizeof(foo)]);
         connection.handleHixieWebSocket();
     }

--- a/src/test/c/CrackedUriTests.cpp
+++ b/src/test/c/CrackedUriTests.cpp
@@ -41,21 +41,21 @@ TEST_CASE("shouldHandleRoot", "[CrackedUriTests]") {
 
 TEST_CASE("shouldHandleTopLevel", "[CrackedUriTests]") {
     CrackedUri uri("/monkey");
-    vector<string> expected = { "monkey" };
+    vector<string> expected = {"monkey"};
     CHECK(uri.path() == expected);
     CHECK(uri.queryParams().empty());
 }
 
 TEST_CASE("shouldHandleSimplePaths", "[CrackedUriTests]") {
     CrackedUri uri("/foo/bar/baz/bungo");
-    vector<string> expected = { "foo", "bar", "baz", "bungo" };
+    vector<string> expected = {"foo", "bar", "baz", "bungo"};
     CHECK(uri.path() == expected);
     CHECK(uri.queryParams().empty());
 }
 
 TEST_CASE("shouldTreatTrailingSlashAsNewPage", "[CrackedUriTests]") {
     CrackedUri uri("/ooh/a/directory/");
-    vector<string> expected = { "ooh", "a", "directory", "" };
+    vector<string> expected = {"ooh", "a", "directory", ""};
     CHECK(uri.path() == expected);
     CHECK(uri.queryParams().empty());
 }
@@ -82,7 +82,7 @@ TEST_CASE("shouldHandleEmptyParams", "[CrackedUriTests]") {
 
 TEST_CASE("shouldHandleDuplicateParams", "[CrackedUriTests]") {
     CrackedUri uri("/?a=a&q=10&q=5&z=yibble&q=100&q=blam");
-    vector<string> expected = { "10", "5", "100", "blam" };
+    vector<string> expected = {"10", "5", "100", "blam"};
     sort(expected.begin(), expected.end());
     auto params = uri.allQueryParams("q");
     sort(params.begin(), params.end());
@@ -92,7 +92,7 @@ TEST_CASE("shouldHandleDuplicateParams", "[CrackedUriTests]") {
 
 TEST_CASE("shouldHandlePathWithQuery", "[CrackedUriTests]") {
     CrackedUri uri("/badger/badger/badger/mushroom?q=snake");
-    vector<string> expected = { "badger", "badger", "badger", "mushroom" };
+    vector<string> expected = {"badger", "badger", "badger", "mushroom"};
     CHECK(uri.path() == expected);
     REQUIRE_FALSE(uri.queryParams().empty());
     CHECK(uri.hasParam("q"));
@@ -101,7 +101,7 @@ TEST_CASE("shouldHandlePathWithQuery", "[CrackedUriTests]") {
 
 TEST_CASE("shouldUnescapePaths", "[CrackedUriTests]") {
     CrackedUri uri("/foo+bar/baz%2f/%40%4F");
-    vector<string> expected = { "foo bar", "baz/", "@O" };
+    vector<string> expected = {"foo bar", "baz/", "@O"};
     CHECK(uri.path() == expected);
 }
 

--- a/src/test/c/EmbeddedContentTests.cpp
+++ b/src/test/c/EmbeddedContentTests.cpp
@@ -22,5 +22,3 @@ TEST_CASE("all files generated", "[EmbeddedContentTests]") {
     CHECK(findEmbeddedContent("/_seasocks.css") != nullptr);
     CHECK(findEmbeddedContent("/_stats.html") != nullptr);
 }
-
-

--- a/src/test/c/HeaderMapTests.cpp
+++ b/src/test/c/HeaderMapTests.cpp
@@ -6,7 +6,7 @@ using namespace seasocks;
 
 namespace {
 
-void emplace(HeaderMap &map, const char *header, const char *value) {
+void emplace(HeaderMap& map, const char* header, const char* value) {
     map.emplace(header, value);
 }
 

--- a/src/test/c/HtmlTests.cpp
+++ b/src/test/c/HtmlTests.cpp
@@ -72,7 +72,7 @@ TEST_CASE("shouldWorkWithAnchors", "[HtmlTests]") {
 }
 
 TEST_CASE("shouldAddAll", "[HtmlTests]") {
-    std::vector<std::string> strings = { "Hi", "Moo", "Foo" };
+    std::vector<std::string> strings = {"Hi", "Moo", "Foo"};
     auto list = ul().addAll(strings, [](const std::string& s) { return li(s); });
     CHECK(list.str() == "<ul><li>Hi</li><li>Moo</li><li>Foo</li></ul>");
 }

--- a/src/test/c/HybiTests.cpp
+++ b/src/test/c/HybiTests.cpp
@@ -40,10 +40,10 @@ using namespace seasocks;
 static IgnoringLogger ignore;
 
 void testSingleString(
-        HybiPacketDecoder::MessageState expectedState,
-        const char* expectedPayload,
-        const std::vector<uint8_t>& v,
-        uint32_t size = 0) {
+    HybiPacketDecoder::MessageState expectedState,
+    const char* expectedPayload,
+    const std::vector<uint8_t>& v,
+    uint32_t size = 0) {
     HybiPacketDecoder decoder(ignore, v);
     std::vector<uint8_t> decoded;
     CHECK(decoder.decodeNextMessage(decoded) == expectedState);
@@ -82,8 +82,8 @@ TEST_CASE("withPartialMessageFollowing", "[HybiTests]") {
 }
 
 TEST_CASE("binaryMessage", "[HybiTests]") {
-    std::vector<uint8_t> packet { 0x82, 0x03, 0x00, 0x01, 0x02 };
-    std::vector<uint8_t> expected_body { 0x00, 0x01, 0x02 };
+    std::vector<uint8_t> packet{0x82, 0x03, 0x00, 0x01, 0x02};
+    std::vector<uint8_t> expected_body{0x00, 0x01, 0x02};
     HybiPacketDecoder decoder(ignore, packet);
     std::vector<uint8_t> decoded;
     CHECK(decoder.decodeNextMessage(decoded) == HybiPacketDecoder::MessageState::BinaryMessage);
@@ -93,7 +93,7 @@ TEST_CASE("binaryMessage", "[HybiTests]") {
 }
 
 TEST_CASE("withTwoMessages", "[HybiTests]") {
-    std::vector<uint8_t> data {
+    std::vector<uint8_t> data{
         0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
         0x81, 0x07, 0x47, 0x6f, 0x6f, 0x64, 0x62, 0x79, 0x65};
     HybiPacketDecoder decoder(ignore, data);
@@ -107,9 +107,9 @@ TEST_CASE("withTwoMessages", "[HybiTests]") {
 }
 
 TEST_CASE("withTwoMessagesOneBeingMaskedd", "[HybiTests]") {
-    std::vector<uint8_t> data {
-        0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,  // hello
-        0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58  // also hello
+    std::vector<uint8_t> data{
+        0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,                        // hello
+        0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58 // also hello
     };
     HybiPacketDecoder decoder(ignore, data);
     std::vector<uint8_t> decoded;
@@ -123,10 +123,9 @@ TEST_CASE("withTwoMessagesOneBeingMaskedd", "[HybiTests]") {
 
 TEST_CASE("regressionBug", "[HybiTests]") {
     // top bit set of second byte of message used to trigger a MASK decode of the remainder
-    std::vector<uint8_t> data {
-        0x82, 0x05, 0x80, 0x81, 0x82, 0x83, 0x84
-    };
-    std::vector<uint8_t> expected_body { 0x80, 0x81, 0x82, 0x83, 0x84 };
+    std::vector<uint8_t> data{
+        0x82, 0x05, 0x80, 0x81, 0x82, 0x83, 0x84};
+    std::vector<uint8_t> expected_body{0x80, 0x81, 0x82, 0x83, 0x84};
     HybiPacketDecoder decoder(ignore, data);
     std::vector<uint8_t> decoded;
     CHECK(decoder.decodeNextMessage(decoded) == HybiPacketDecoder::MessageState::BinaryMessage);

--- a/src/test/c/JsonTests.cpp
+++ b/src/test/c/JsonTests.cpp
@@ -41,7 +41,7 @@ TEST_CASE("shouldHandleMaps", "[JsonTests]") {
 
 TEST_CASE("shouldHandleQuotedStrings", "[JsonTests]") {
     CHECK(makeMap("key", "I have \"quotes\"") ==
-                  "{\"key\":\"I have \\\"quotes\\\"\"}");
+          "{\"key\":\"I have \\\"quotes\\\"\"}");
 }
 
 TEST_CASE("shouldHandleNewLinesInStrings", "[JsonTests]") {
@@ -75,19 +75,19 @@ TEST_CASE("shouldHandleNonAsciiChars", "[JsonTests]") {
 }
 
 struct Object {
-    void jsonToStream(std::ostream &ostr) const {
+    void jsonToStream(std::ostream& ostr) const {
         ostr << makeMap("object", true);
     }
     // Clang is pernickity about this. We don't want use this function
     // but it's here to catch errors where we accidentally use it instead of the
     // jsonToStream.
-    friend std::ostream &operator << (std::ostream &o, const Object &) {
+    friend std::ostream& operator<<(std::ostream& o, const Object&) {
         return o << "Not this one";
     }
 };
 
 struct Object2 {
-    friend std::ostream &operator << (std::ostream &o, const Object2 &) {
+    friend std::ostream& operator<<(std::ostream& o, const Object2&) {
         return o << "This is object 2";
     }
 };
@@ -124,7 +124,7 @@ TEST_CASE("handlesArrays", "[JsonTests]") {
     CHECK(makeArray("abc") == R"(["abc"])");
     CHECK(makeArray("a", "b", "c") == R"(["a","b","c"])");
     CHECK(makeArray({"a", "b", "c"}) == R"(["a","b","c"])");
-    std::vector<JsonnedString> strs = { to_json(false), to_json(true) };
+    std::vector<JsonnedString> strs = {to_json(false), to_json(true)};
     CHECK(makeArrayFromContainer(strs) == R"([false,true])");
 }
 
@@ -138,8 +138,7 @@ TEST_CASE("handlesMaps", "[JsonTests]") {
     std::map<std::string, JsonnedString> unordMap;
     unordMap["hello"] = to_json(true);
     unordMap["goodbye"] = to_json(false);
-    CHECK_THAT(makeMapFromContainer(unordMap), Catch::Equals(R"({"goodbye":false,"hello":true})")
-                                            || Catch::Equals(R"({"hello":true,"goodbye":false})"));
+    CHECK_THAT(makeMapFromContainer(unordMap), Catch::Equals(R"({"goodbye":false,"hello":true})") || Catch::Equals(R"({"hello":true,"goodbye":false})"));
 }
 
 }

--- a/src/test/c/MockServerImpl.h
+++ b/src/test/c/MockServerImpl.h
@@ -39,21 +39,40 @@ public:
     std::string staticPath;
     std::unordered_map<std::string, std::shared_ptr<WebSocket::Handler>> handlers;
 
-    void remove(Connection* /*connection*/) override {}
-    bool subscribeToWriteEvents(Connection* /*connection*/) override {return false;};
-    bool unsubscribeFromWriteEvents(Connection* /*connection*/) override {return false;}
-    const std::string& getStaticPath() const override { return staticPath; }
-    std::shared_ptr<WebSocket::Handler> getWebSocketHandler(const char *endpoint) const override {
+    void remove(Connection* /*connection*/) override {
+    }
+    bool subscribeToWriteEvents(Connection* /*connection*/) override {
+        return false;
+    };
+    bool unsubscribeFromWriteEvents(Connection* /*connection*/) override {
+        return false;
+    }
+    const std::string& getStaticPath() const override {
+        return staticPath;
+    }
+    std::shared_ptr<WebSocket::Handler> getWebSocketHandler(const char* endpoint) const override {
         auto it = handlers.find(endpoint);
-        if (it == handlers.end()) return std::shared_ptr<WebSocket::Handler>();
+        if (it == handlers.end())
+            return std::shared_ptr<WebSocket::Handler>();
         return it->second;
     }
-    bool isCrossOriginAllowed(const std::string &/*endpoint*/) const override { return false; }
-    std::shared_ptr<Response> handle(const Request &/*request*/) override { return std::shared_ptr<Response>(); }
-    std::string getStatsDocument() const override { return ""; }
-    void checkThread() const override { }
-    Server &server() override { throw std::runtime_error("not supported"); };
-    size_t clientBufferSize() const override { return 512 * 1024; }
+    bool isCrossOriginAllowed(const std::string& /*endpoint*/) const override {
+        return false;
+    }
+    std::shared_ptr<Response> handle(const Request& /*request*/) override {
+        return std::shared_ptr<Response>();
+    }
+    std::string getStatsDocument() const override {
+        return "";
+    }
+    void checkThread() const override {
+    }
+    Server& server() override {
+        throw std::runtime_error("not supported");
+    };
+    size_t clientBufferSize() const override {
+        return 512 * 1024;
+    }
 };
 
 }

--- a/src/test/c/ResponseTests.cpp
+++ b/src/test/c/ResponseTests.cpp
@@ -64,4 +64,3 @@ TEST_CASE("html response", "[ResponseTests]") {
     CHECK(resp->getAdditionalHeaders().empty() == true);
     CHECK(resp->keepConnectionAlive() == true);
 }
-

--- a/src/test/c/ServerTests.cpp
+++ b/src/test/c/ServerTests.cpp
@@ -39,18 +39,19 @@ TEST_CASE("Server tests", "[ServerTests]") {
     auto logger = std::make_shared<IgnoringLogger>();
     Server server(logger);
     REQUIRE(server.startListening(0));
-    std::thread seasocksThread([&]{
+    std::thread seasocksThread([&] {
         REQUIRE(server.loop());
     });
 
     std::atomic<int> test(0);
     SECTION("execute should work") {
-        server.execute([&]{
+        server.execute([&] {
             CHECK(test == 0);
             test++;
         });
         for (int i = 0; i < 1000 * 1000 * 1000; ++i) {
-            if (test) break;
+            if (test)
+                break;
         }
         CHECK(test == 1);
     }
@@ -66,7 +67,8 @@ TEST_CASE("Server tests", "[ServerTests]") {
         server.execute([&] { latch = true; });
         for (int i = 0; i < 1000; ++i) {
             usleep(1000);
-            if (latch) break;
+            if (latch)
+                break;
         }
         CHECK(latch == 1);
         CHECK(test == 10000);


### PR DESCRIPTION
Clang-Format configuration and a related CMake target (#102). The latter is only available if `clang-format` is found.

The new target makes it easy to format all sources:  use e.g. `make clang-format`.

### To Do

- [x] Clang Format config
- [x] Review the formatting settings
- [x] Make it easy to use
- [x] Reformat code


Not everything is matching the current formatting perfectly. E.g. multiline parameters are formatted a little different, but braces, blocks, indention should be ok (… mostly).

Please let me know what you think or what has to be changed.

### Links

- https://zed0.co.uk/clang-format-configurator
- https://clang.llvm.org/docs/ClangFormatStyleOptions.html