### PR TITLE
Provide SeasocksConfig.cmake files when installed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,15 @@ endif ()
 
 add_subdirectory("src")
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/
+)
+

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -68,12 +68,18 @@ else()
 endif()
 
 add_library(seasocks_obj OBJECT ${SEASOCKS_SOURCE_FILES})
-target_include_directories(seasocks_obj PUBLIC .)
+target_include_directories(seasocks_obj PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/.>
+)
 set_property(TARGET seasocks_obj PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 
 add_library(seasocks STATIC $<TARGET_OBJECTS:seasocks_obj> $<TARGET_OBJECTS:embedded>)
 add_library(Seasocks::seasocks ALIAS seasocks)
-target_include_directories(seasocks PUBLIC .)
+target_include_directories(seasocks PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/.>
+)
 target_link_libraries(seasocks PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 if (DEFLATE_SUPPORT)
     target_link_libraries(seasocks PRIVATE "${ZLIB_LIBRARIES}")
@@ -81,13 +87,16 @@ endif()
 
 add_library(seasocks_so SHARED $<TARGET_OBJECTS:seasocks_obj> $<TARGET_OBJECTS:embedded>)
 add_library(Seasocks::seasocks_so ALIAS seasocks_so)
-target_include_directories(seasocks_so PUBLIC ${ZLIB_INCLUDE_DIRS} .)
+target_include_directories(seasocks_so PUBLIC ${ZLIB_INCLUDE_DIRS} 
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/.>
+)
 if (DEFLATE_SUPPORT)
     target_link_libraries(seasocks_so PRIVATE ${CMAKE_THREAD_LIBS_INIT} "${ZLIB_LIBRARIES}")
 endif()
 set_target_properties(seasocks_so PROPERTIES OUTPUT_NAME seasocks VERSION ${PROJECT_VERSION})
 
-install(TARGETS seasocks seasocks_so
+install(TARGETS seasocks seasocks_so EXPORT ${PROJECT_NAME}Config
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -96,8 +105,16 @@ install(DIRECTORY seasocks
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h"
         )
+# export for build tree.
 export(
     TARGETS seasocks seasocks_so
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+)
+# export for install.
+install(
+  EXPORT ${PROJECT_NAME}Config
+  FILE ${PROJECT_NAME}Config.cmake
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/
 )


### PR DESCRIPTION
Back again with more cmake improvements, I've finally got to the point where I had to make install rules for my tracing framework [Scalopus](https://github.com/iwanders/scalopus/). I had fixed using Seasocks through `find_package` from the build tree with https://github.com/mattgodbolt/seasocks/pull/108, but hadn't tried compiling against an installed version of Seasocks yet. When I tried that my `find_package(Seasocks)` instruction failed. The current `make install` of Seasocks only installs the headers and the libraries. This PR adds installing a `SeasocksConfig.cmake` which allows cmake to find the installed `Seasocks` through `find_package`. To do this we rely on [install(EXPORT)](https://cmake.org/cmake/help/v3.3/command/install.html?highlight=install#installing-exports), this exports the targets in the `Seasocks::` namespace as is convention.

This can be tested by setting `-DCMAKE_INSTALL_PREFIX:PATH=/tmp/upstream_prefix/` during compilation, this prefixes the `make install` step with that folder. Current upstream installs:
```
./upstream_prefix/lib/libseasocks.a
./upstream_prefix/lib/libseasocks.so.1.4.1
./upstream_prefix/lib/libseasocks.so
./upstream_prefix/include/seasocks/Response.h
<snip>
```
With this change, prefix set to `/tmp/with_change_prefix/`:
```
./with_change_prefix/lib/libseasocks.a
./with_change_prefix/lib/libseasocks.so.1.4.1
./with_change_prefix/lib/libseasocks.so
./with_change_prefix/lib/cmake/Seasocks/SeasocksConfig-noconfig.cmake
./with_change_prefix/lib/cmake/Seasocks/SeasocksConfig.cmake
./with_change_prefix/lib/cmake/Seasocks/SeasocksConfigVersion.cmake
./with_change_prefix/include/seasocks/Response.h
<snip>
```

So we install both the `SeasocksConfig.cmake` file and the associated version file. This allows us to use the `find_package` command for Seasocks and also allows using the version field in this command. After using `make install` we can now use a `CMakeLists.txt` like:
```cmake
cmake_minimum_required(VERSION 3.3)
find_package(Seasocks 1.4.0) # Requires at least version 1.4.0.
add_executable(my_server serve.cpp)
target_link_libraries(my_server Seasocks::seasocks)
```
With [serve.cpp](https://github.com/mattgodbolt/seasocks/blob/master/src/app/c/serve.cpp) from anywhere on our system and cmake will be able to find the installed version of Seasocks.