### PR TITLE
Allow disabling the example applications.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ project(Seasocks VERSION 1.4.1)
 
 option(UNITTESTS "Build unittests." ON)
 option(COVERAGE "Build with code coverage enabled" OFF)
+option(SEASOCKS_EXAMPLE_APP "Build the example applications." ON) 
 option(DEFLATE_SUPPORT "Include support for deflate (requires zlib)." ON)
+
 if (DEFLATE_SUPPORT)
     set(DEFLATE_SUPPORT_BOOL "true")
 else ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,10 @@
 
 add_subdirectory("main/c")
 add_subdirectory("main/web")
-add_subdirectory("app/c")
+
+if (SEASOCKS_EXAMPLE_APP)
+  add_subdirectory("app/c")
+endif ()
 
 if (UNITTESTS)
     find_program(CMAKE_MEMORYCHECK_COMMAND valgrind)


### PR DESCRIPTION
Title pretty much explains it; provide an option to disable the example applications from the `app/c` folder. When used in an embedded project these are unnecessary.

I broke convention in the option naming and prefixed it with `SEASOCKS_`, this is because this avoids option name collisions with multiple embedded libraries in one cmake project.