### PR TITLE
Associate userdata to a connection

### DIFF
--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -70,6 +70,8 @@ public:
     virtual void send(const char* webSocketResponse) override;
     virtual void send(const uint8_t* webSocketResponse, size_t length) override;
     virtual void close() override;
+    virtual void setUserdata(std::shared_ptr<void> udata) { _userdata = udata; }
+    virtual std::shared_ptr<void> getUserdata() const { return _userdata; }
 
     // From Request.
     virtual std::shared_ptr<Credentials> credentials() const override;
@@ -226,6 +228,8 @@ private:
         SENDING_RESPONSE_BODY
     };
     State _state;
+
+    std::shared_ptr<void> _userdata;
 
     void writeChunkHeader(size_t size);
 };

--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -70,8 +70,8 @@ public:
     virtual void send(const char* webSocketResponse) override;
     virtual void send(const uint8_t* webSocketResponse, size_t length) override;
     virtual void close() override;
-    virtual void setUserdata(std::shared_ptr<void> udata) { _userdata = udata; }
-    virtual std::shared_ptr<void> getUserdata() const { return _userdata; }
+    virtual void setUserdata(std::shared_ptr<void> udata) override { _userdata = udata; }
+    virtual std::shared_ptr<void> getUserdata() const override { return _userdata; }
 
     // From Request.
     virtual std::shared_ptr<Credentials> credentials() const override;

--- a/src/main/c/seasocks/WebSocket.h
+++ b/src/main/c/seasocks/WebSocket.h
@@ -95,6 +95,16 @@ public:
         }
     };
 
+    /**
+     * Set a userdata associated with this connection.
+     */
+    virtual void setUserdata(std::shared_ptr<void> udata) = 0;
+    /**
+     * Get the userdata stored in this connection.
+     */
+    virtual std::shared_ptr<void> getUserdata() const = 0;
+
+
 protected:
     // To delete a WebSocket, just close it. It is owned by the Server, and
     // the server will delete it when it's finished.


### PR DESCRIPTION
I really like this project, however, I found one pretty big problem for me.
I tend to have data associated with a connection (like authentication, jsonrpc states and similar).
This would normally involve a mapping between seasocks::WebSocket* and my data, which makes it more complex and hurts multithreading.

This pull request adds a userdata field to the connection class (currently a shared_ptr, to allow for RAII, but feel free to change it to a plain void* if you like to). This allows for simple and fast access to all required data.