### PR TITLE
Fixes for Ubuntu Eoan with gcc 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif ()
 find_package(Threads)
 
 
-find_program(PYTHON_BIN python DOC "Python executable")
+find_program(PYTHON_BIN NAMES python python3 DOC "Python executable")
 
 if (NOT PYTHON_BIN)
     message(SEND_ERROR "Python not found")

--- a/src/main/c/Server.cpp
+++ b/src/main/c/Server.cpp
@@ -90,13 +90,14 @@ std::ostream& operator<<(std::ostream& o, const EventBits& b) {
 
 constexpr int EpollTimeoutMillis = 500; // Twice a second is ample.
 constexpr int DefaultLameConnectionTimeoutSeconds = 10;
-pid_t gettid() {
-    return static_cast<pid_t>(syscall(SYS_gettid));
-}
 
 }
 
 namespace seasocks {
+
+pid_t gettid() {
+    return static_cast<pid_t>(syscall(SYS_gettid));
+}
 
 constexpr size_t Server::DefaultClientBufferSize;
 


### PR DESCRIPTION
Two fixes for compiling with Ubuntu Eoan, which ships with gcc 9.

One fix is that we allow `python3` to be identified as the Python binary. Just `python` is not available by default, the `gen_embedded.py` script works in python3, so there is no reason not to use it if it is available.

Second fix is to resolve an ambiguous overload for `gettid` from the anonymous namespace;
```
/vagrant/ws/seasocks/src/main/c/Server.cpp: In member function ‘bool seasocks::Server::loop()’:
/vagrant/ws/seasocks/src/main/c/Server.cpp:408:24: error: call of overloaded ‘gettid()’ is ambiguous
  408 |     _threadId = gettid();
      |                        ^
In file included from /usr/include/unistd.h:1170,
                 from /vagrant/ws/seasocks/src/main/c/Server.cpp:49:
/usr/include/x86_64-linux-gnu/bits/unistd_ext.h:34:16: note: candidate: ‘__pid_t gettid()’
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
/vagrant/ws/seasocks/src/main/c/Server.cpp:93:7: note: candidate: ‘pid_t {anonymous}::gettid()’
   93 | pid_t gettid() {
      |       ^~~~~~
```

I fixed this by moving the `gettid()` function from the anonymous namespace into the `seasocks` namespace. I'm not sure why we have this function to be honest, why not use [gettid](http://man7.org/linux/man-pages/man2/gettid.2.html) from `sys/types.h`? Also, this function is not in the header file, should we mark it `static`?