### PR TITLE
Handle exceptions of invalid WS versions

### DIFF
--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -917,7 +917,13 @@ bool Connection::handlePageRequest() {
     auto uri = _request->getRequestUri();
     if (!response && _request->verb() == Request::Verb::WebSocket) {
         _webSocketHandler = _server.getWebSocketHandler(uri.c_str());
-        const auto webSocketVersion = std::stoi(_request->getHeader("Sec-WebSocket-Version"));
+        int webSocketVersion{0};
+        try {
+            webSocketVersion = std::stoi(_request->getHeader("Sec-WebSocket-Version"));
+        } catch (const std::logic_error& ex) {
+            LS_WARNING(_logger, "Invalid Sec-WebSocket-Version '" << _request->getHeader("Sec-WebSocket-Version") << "'");
+            return sendError(ResponseCode::UpgradeRequired, "Invalid Sec-WebSocket-Version received");
+        }
         if (!_webSocketHandler) {
             LS_WARNING(_logger, "Couldn't find WebSocket end point for '" << uri << "'");
             return send404();

--- a/src/main/c/seasocks/ResponseCodeDefs.h
+++ b/src/main/c/seasocks/ResponseCodeDefs.h
@@ -61,6 +61,8 @@ SEASOCKS_DEFINE_RESPONSECODE(403, Forbidden, "Forbidden")
 SEASOCKS_DEFINE_RESPONSECODE(404, NotFound, "Not Found")
 SEASOCKS_DEFINE_RESPONSECODE(405, MethodNotAllowed, "Method Not Allowed")
 // more here...
+SEASOCKS_DEFINE_RESPONSECODE(426, UpgradeRequired, "Upgrade Required")
+// more here...
 
 SEASOCKS_DEFINE_RESPONSECODE(500, InternalServerError, "Internal Server Error")
 SEASOCKS_DEFINE_RESPONSECODE(501, NotImplemented, "Not Implemented")


### PR DESCRIPTION
Handling of missing or invalid `Sec-WebSocket-Version` header added (#131). 