### PR TITLE
Address @madebr post-checkin comments. Doesn't currently build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -78,6 +78,7 @@ class SeasocksConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Seasocks"
         self.cpp_info.names["cmake_find_package_multi"] = "Seasocks"
         self.cpp_info.components["libseasocks"].libs = ["seasocks"]
+        self.cpp_info.components["libseasocks"].system_libs = ["pthread"]
         # Set the name of the generated seasocks target: `Seasocks::seasocks`
         self.cpp_info.components["libseasocks"].names["cmake_find_package"] = "seasocks"
         self.cpp_info.components["libseasocks"].names["cmake_find_package_multi"] = "seasocks"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.3)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(Threads)
+find_package(Seasocks REQUIRED)
 
 add_executable(seasocks_test seasocks_test.cpp)
-target_link_libraries(seasocks_test ${CONAN_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(seasocks_test PRIVATE Seasocks::seasocks)


### PR DESCRIPTION
I made the changes you suggested in the PR, but `conan create . seasocks/1.4.4@` fails with:

```
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found
[HOOK - conan-center.py] pre_build(): [FPIC MANAGEMENT (KB-H007)] OK
seasocks/1.4.4 (test package): Calling build()
-- The CXX compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: called by CMake conan helper
-- Conan: Adjusting output directories
-- Conan: Using cmake targets configuration
-- Library seasocks found /home/mgodbolt/.conan/data/seasocks/1.4.4/_/_/package/f55ba25bd602c823ae2a588a3723c6f03570ff59/lib/libseasocks.so
-- Library z found /home/mgodbolt/.conan/data/zlib/1.2.11/_/_/package/6af9cc7cb931c5ad942174fd7838eb655717c709/lib/libz.a
-- Conan: Adjusting default RPATHs Conan policies
-- Conan: Adjusting language standard
-- Conan: Compiler GCC>=5, checking major version 9
-- Conan: Checking correct version: 9
-- Conan: C++ stdlib: libstdc++
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


-- Build files have been written to: /home/mgodbolt/dev/personal/seasocks/test_package/build/7e3f3c9f8b0319ca5c01315759aeda2f877da74f
Scanning dependencies of target seasocks_test
[ 50%] Building CXX object CMakeFiles/seasocks_test.dir/seasocks_test.cpp.o
[100%] Linking CXX executable bin/seasocks_test
/usr/bin/ld: CMakeFiles/seasocks_test.dir/seasocks_test.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/seasocks_test.dir/build.make:85: bin/seasocks_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/seasocks_test.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
ERROR: seasocks/1.4.4 (test package): Error in build() method, line 12
	cmake.build()
	ConanException: Error 2 while executing cmake --build '/home/mgodbolt/dev/personal/seasocks/test_package/build/7e3f3c9f8b0319ca5c01315759aeda2f877da74f' '--' '-j36'
```