### PR TITLE
Fix issue where socket errors print gibberish

### DIFF
--- a/src/main/c/StringUtil.cpp
+++ b/src/main/c/StringUtil.cpp
@@ -74,10 +74,7 @@ std::string trimWhitespace(const std::string& str) {
 }
 
 std::string getLastError() {
-    char errbuf[1024];
-    const auto ignore = strerror_r(errno, errbuf, sizeof(errbuf));
-    static_cast<void>(ignore);
-    return errbuf;
+    return strerror(errno);
 }
 
 std::string formatAddress(const sockaddr_in& address) {

--- a/src/main/c/StringUtil.cpp
+++ b/src/main/c/StringUtil.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <system_error>
 
 namespace seasocks {
 
@@ -74,7 +75,8 @@ std::string trimWhitespace(const std::string& str) {
 }
 
 std::string getLastError() {
-    return strerror(errno);
+    const auto error = std::generic_category().default_error_condition(errno);
+    return "(" + std::to_string(error.value()) + ") " + error.message();
 }
 
 std::string formatAddress(const sockaddr_in& address) {


### PR DESCRIPTION
When I try to start seasocks, I keep getting an error message similar to this: `ERROR: Unable to bind socket: �C�`. 
What was really happening was that I was trying to bind to an in-use socket. This PR fixes that error message and makes it legible.