### PR TITLE
clang-12 CI fix and GH Action upate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       JOBS: 2
     name: "${{ matrix.build_config.cc }}-${{ matrix.build_config.version }} ${{ matrix.build_config.args }}"
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: Setup Clang
         if: matrix.build_config.cc == 'clang'
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
       CXX: g++-10
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: CodeQL Initialization
         uses: github/codeql-action/init@v1
         with:

--- a/scripts/ci_setup_clang.sh
+++ b/scripts/ci_setup_clang.sh
@@ -6,3 +6,7 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${VERSION} main"
 apt update
 apt-get install -y clang-${VERSION} libc++-${VERSION}-dev libc++abi-${VERSION}-dev
+
+if [[ ${VERSION} -ge 12 ]]; then
+    apt-get install -y --no-install-recommends libunwind-${VERSION}-dev
+fi


### PR DESCRIPTION
Clang 12 has introduced a dependency to `libunwind-12-dev` recently. Additionally, the *checkout* step has switched to `main` as default branch.