### PR TITLE
Handle non-numeric Content-Length header

### DIFF
--- a/src/main/c/PageRequest.cpp
+++ b/src/main/c/PageRequest.cpp
@@ -63,7 +63,11 @@ size_t PageRequest::getUintHeader(const std::string& name) const {
     if (iter == _headers.end()) {
         return 0u;
     }
-    const auto val = std::stoi(iter->second);
+    try {
+        const auto val = std::stoi(iter->second);
+    } catch (const std::logic_error&) {
+        return 0u;
+    }
     if (val < 0) {
         return 0u;
     }


### PR DESCRIPTION
Thanks for a great library! I'm using it in a few applications at work and getting crashes due to internal vulnerability scans looking for exploitable applications using log4j. Returning 0 seems sensible as it's being done in the other failure cases here.

Allow non-numeric or overly large header values for Content-Length, returning 0 instead.