### PR TITLE
Clang 13 and 14 CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
           - { cc: gcc, cxx: g++, version: 9 }
           - { cc: gcc, cxx: g++, version: 8 }
           - { cc: gcc, cxx: g++, version: 7 }
+          - { cc: clang, cxx: clang++, version: 14 }
+          - { cc: clang, cxx: clang++, version: 13 }
           - { cc: clang, cxx: clang++, version: 12 }
           - { cc: clang, cxx: clang++, version: 11 }
           - { cc: clang, cxx: clang++, version: 10 }


### PR DESCRIPTION
Adds builds for latest Clang versions.

Both issue an error due to possible UB though:

```
/home/runner/work/seasocks/seasocks/src/main/c/md5/md5.cpp:190:25: error: performing pointer subtraction with a null pointer may have undefined behavior [-Werror,-Wnull-pointer-subtraction]
            if (!((data - (const md5_byte_t*) 0) & 3)) {
                        ^ ~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```