### PR TITLE
Update CodeQL to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: CodeQL Initialization
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: cpp
           queries: +security-and-quality
@@ -26,4 +26,4 @@ jobs:
           cmake . -Bbuild
           cmake --build build
       - name: CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL v2 is available, therefore v1 is scheduled for deprecation at the end of the year.

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/
