### PR TITLE
MD5: Removed null pointer subtraction

### DIFF
--- a/src/main/c/md5/md5.cpp
+++ b/src/main/c/md5/md5.cpp
@@ -79,6 +79,7 @@
 #include "md5/md5.h"
 
 #include <cstring>
+#include <cstdint>
 
 #undef BYTE_ORDER /* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
@@ -187,7 +188,7 @@ md5_process(md5_state_t* pms, const md5_byte_t* data /*[64]*/) {
          * On little-endian machines, we can process properly aligned
          * data without copying it.
          */
-            if (!((data - (const md5_byte_t*) 0) & 3)) {
+            if (!(uintptr_t(data) & 3)) {
                 /* data are properly aligned */
                 X = (const md5_word_t*) data;
             } else {


### PR DESCRIPTION
Hi all,

Thanks for this great project!

Created this PR after initial discussion here:  https://github.com/mattgodbolt/seasocks/pull/165

My environment was Ubuntu 22.04, with the system clang14 package (Ubuntu clang version 14.0.0-1ubuntu1)

Before this change, this is the compile error:

```
/home/trigen/projects/build-config/seasocks/seasocks/src/main/c/md5/md5.cpp:190:25: error: performing pointer subtraction with a null pointer may have undefined behavior [-Werror,-Wnull-pointer-subtraction]
            if (!((data - (const md5_byte_t*) 0) & 3)) {
                        ^ ~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/main/c/CMakeFiles/seasocks.dir/build.make:146: src/main/c/CMakeFiles/seasocks.dir/md5/md5.cpp.o] Error 1
```

I researched it a little bit, found the PR I commented on previously, and further googling found a fix made by Maxim Sharabayko in a different project: https://github.com/Haivision/srt/pull/2392
The fix made sense to me, tried it, and also solved the compilation issue for me.

Cheers,
Ray