### PR TITLE
Fix builds for older GCCs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           - { compiler: gcc, version: 9 }
           - { compiler: gcc, version: 8 }
           - { compiler: gcc, version: 7 }
+          - { compiler: gcc, version: 6 }
+          - { compiler: gcc, version: 5 }
           - { compiler: clang, version: 14 }
           - { compiler: clang, version: 13 }
           - { compiler: clang, version: 12 }

--- a/src/main/c/seasocks/StrCompare.h
+++ b/src/main/c/seasocks/StrCompare.h
@@ -2,12 +2,12 @@
 // StringCompare.h, written by sjk7 (Steve) 22/10/2021
 // Inherits seasocks licence.
 
-#include <string_view>
+#include <string>
 #include <cctype>
 #include <algorithm>
 
-static inline bool compareCaseInsensitive(const std::string_view lhs,
-                                          const std::string_view rhs) noexcept {
+static inline bool compareCaseInsensitive(const std::string& lhs,
+                                          const std::string& rhs) noexcept {
     // replaces "return strcasecmp(lhs.c_str(), rhs.c_str()) == 0" directly
     // test coverage provided by:
     // TEST_CASE("case insensitive string comparison", "[ToStringTests]")


### PR DESCRIPTION
Not sure if we want to keep this or just drop support for them. But see #174 