### PR TITLE
Re-enable Clang 15 CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - { compiler: gcc, version: 9 }
           - { compiler: gcc, version: 8 }
           - { compiler: gcc, version: 7 }
-            #- { compiler: clang, version: 15 } # Disabled due to wrong arch (#179)
+          - { compiler: clang, version: 15 }
           - { compiler: clang, version: 14 }
           - { compiler: clang, version: 13 }
           - { compiler: clang, version: 12 }


### PR DESCRIPTION
 Upstream images have been fixed and Clang 15 works again.

closes #179 