### PR TITLE
Require Threads package and add missing Clang 14 package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.h.in internal/Config.h @ONLY)
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    # anything higher than /W3 results in warnings from Catch2, standard libraries, etc 
+    # anything higher than /W3 results in warnings from Catch2, standard libraries, etc
     add_compile_options(/W4 /WX)
 else()
     add_compile_options(-Wall -Werror -Wextra -pedantic -pedantic-errors)
@@ -50,7 +50,7 @@ if (COVERAGE)
     set(CMAKE_SHARED_LINKER_FLAGS "${SHARED_EXE_LINKER_FLAGS} --coverage")
 endif ()
 
-find_package(Threads)
+find_package(Threads REQUIRED)
 find_package(PythonInterp)
 
 if (NOT PYTHONINTERP_FOUND)

--- a/scripts/ci_setup_clang.sh
+++ b/scripts/ci_setup_clang.sh
@@ -8,3 +8,7 @@ apt-get install -y libc++-${VERSION}-dev libc++abi-${VERSION}-dev
 if [[ ${VERSION} -ge 12 ]]; then
     apt-get install -y --no-install-recommends libunwind-${VERSION}-dev
 fi
+
+if [[ "${VERSION}" -eq 14 ]]; then
+    apt-get install -y --no-install-recommends libclang-rt-${VERSION}-dev
+fi


### PR DESCRIPTION
Fixes the `Could NOT find Threads (missing: Threads_FOUND)` error on Clang 14.