### PR TITLE
Require CMake 3.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(Seasocks VERSION 1.4.5)
 
 if(APPLE)


### PR DESCRIPTION
According to [CMake 3.27 release notes](https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features):

> Compatibility with versions of CMake older than 3.5 is now deprecated and will be removed from a future version. 