### PR TITLE
Fix x86 build

### DIFF
--- a/src/main/c/HybiPacketDecoder.cpp
+++ b/src/main/c/HybiPacketDecoder.cpp
@@ -66,7 +66,7 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
     deflateNeeded = !!(reservedBits & 0x40);
 
     auto opcode = static_cast<Opcode>(_buffer[_messageStart] & 0xf);
-    size_t payloadLength = _buffer[_messageStart + 1] & 0x7fu;
+    uint64_t payloadLength = _buffer[_messageStart + 1] & 0x7fu;
     auto maskBit = _buffer[_messageStart + 1] & 0x80;
     auto ptr = _messageStart + 2;
     if (payloadLength == 126) {
@@ -103,7 +103,7 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
     }
 
     messageOut.clear();
-    messageOut.reserve(payloadLength);
+    messageOut.reserve(static_cast<size_t>(payloadLength));
     for (auto i = 0u; i < payloadLength; ++i) {
         auto byteShift = (3 - (i & 3)) * 8;
         messageOut.push_back(static_cast<uint8_t>((_buffer[ptr++] ^ (mask >> byteShift)) & 0xff));

--- a/src/main/c/seasocks/StreamingResponse.cpp
+++ b/src/main/c/seasocks/StreamingResponse.cpp
@@ -51,7 +51,7 @@ void StreamingResponse::handle(std::shared_ptr<ResponseWriter> writer) {
         bool isGood = stream->good();
         if (isGood || isEof) {
             // everything is fine, push data to client
-            writer->payload(buffer.get(), stream->gcount(), flush);
+            writer->payload(buffer.get(), static_cast<size_t>(stream->gcount()), flush);
         }
 
         if (!isGood) {


### PR DESCRIPTION
This fixes compiler warnings treated as errors when compiling for x86 on Windows:
> D:\buildtrees\seasocks\src\v1.4.5-50543c2dd9.clean\src\main\c\seasocks\StreamingResponse.cpp(54): error C2220: the following warning is treated as an error
D:\buildtrees\seasocks\src\v1.4.5-50543c2dd9.clean\src\main\c\seasocks\StreamingResponse.cpp(54): warning C4244: 'argument': conversion from 'std::streamsize' to 'size_t', possible loss of data

> D:\buildtrees\seasocks\src\v1.4.5-50543c2dd9.clean\src\main\c\HybiPacketDecoder.cpp(86): error C2220: the following warning is treated as an error
D:\buildtrees\seasocks\src\v1.4.5-50543c2dd9.clean\src\main\c\HybiPacketDecoder.cpp(86): warning C4244: '=': conversion from 'uint64_t' to 'size_t', possible loss of data