### PR TITLE
Drop compiler running on a deprecated (by GH actions) version of Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
           - { compiler: clang, version: 13 }
           - { compiler: clang, version: 12 }
           - { compiler: clang, version: 11 }
-          - { compiler: clang, version: 10 }
-          - { compiler: clang, version: 9 }
           - { compiler: gcc, version: 10, args: "-DDEFLATE_SUPPORT=OFF" }
     container:
       image: ${{ matrix.build_config.compiler == 'clang' && 'teeks99/clang-ubuntu' || matrix.build_config.compiler }}:${{ matrix.build_config.version }}


### PR DESCRIPTION
Clang 9 and 10 use an Ubuntu 18.04 based image, which isn't supported by the latest version of the checkout action.

https://github.com/actions/checkout/issues/1442