### PR TITLE
CI builds: Add Clang 18, remove GCC 7/8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - { compiler: gcc, version: 9 }
           - { compiler: gcc, version: 8 }
           - { compiler: gcc, version: 7 }
+          - { compiler: clang, version: 18 }
           - { compiler: clang, version: 17 }
           - { compiler: clang, version: 16 }
           - { compiler: clang, version: 15 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
           - { compiler: gcc, version: 11 }
           - { compiler: gcc, version: 10 }
           - { compiler: gcc, version: 9 }
-          - { compiler: gcc, version: 8 }
-          - { compiler: gcc, version: 7 }
           - { compiler: clang, version: 18 }
           - { compiler: clang, version: 17 }
           - { compiler: clang, version: 16 }


### PR DESCRIPTION
Adds a CI build for the latest Clang 18.

GCC 7 and 8 are based on an outdated image and their git installation doesn't seem to support features used by GH Actions. I suggest to drop them as they are quite old now.
