### PR TITLE
add cmake message about zlib depend on deflate support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION}")
 message(STATUS "Unittests: ${UNITTESTS}")
 message(STATUS "Coverage: ${COVERAGE}")
 message(STATUS "Building shared: ${SEASOCKS_SHARED}")
-
+message(STATUS "Deflate support (requires zlib): ${DEFLATE_SUPPORT}")
 
 set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/src/test/suppressions.txt" CACHE INTERNAL "")
 include(CTest)


### PR DESCRIPTION
Would have saved me some time.

If you don't need deflate support and don't want to have to link zlib, so you get:
```
libseasocks.a(ZlibContext.cpp.o): in function `seasocks::ZlibContext::Impl::Impl(int, int, int)':
ZlibContext.cpp:(.text._ZN8seasocks11ZlibContext4ImplC2Eiii[_ZN8seasocks11ZlibContext4ImplC5Eiii]+0x98): undefined reference to `deflateInit2_'
```
you should cmake with `-DDEFLATE_SUPPORT=OFF` which takes a bit of reading to find. A cmake message makes it clear from the start. 