### PR TITLE
Add Clang 22 CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - { compiler: gcc, version: 11 }
           - { compiler: gcc, version: 10 }
           - { compiler: gcc, version: 9 }
+          - { compiler: clang, version: 22 }
           - { compiler: clang, version: 21 }
           - { compiler: clang, version: 20 }
           - { compiler: clang, version: 19 }

--- a/src/test/c/CMakeLists.txt
+++ b/src/test/c/CMakeLists.txt
@@ -3,7 +3,7 @@ Include(FetchContent)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.13.0
+        GIT_TAG v3.14.0
 )
 
 FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
Update Catch to 3.14.0 with Clang 22 support.