### PR TITLE
Add HTTP compression using gzip

### DIFF
--- a/src/app/c/ph_test.cpp
+++ b/src/app/c/ph_test.cpp
@@ -64,6 +64,7 @@ int main(int /*argc*/, const char* /*argv*/[]) {
     auto logger = std::make_shared<PrintfLogger>(Logger::Level::Info);
 
     Server server(logger);
+    server.setHttpCompressionEnabled(true);
     server.addPageHandler(std::make_shared<MyPageHandler>());
 
     server.serve("src/ws_test_web", 9090);

--- a/src/main/c/AcceptEncoding.cpp
+++ b/src/main/c/AcceptEncoding.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017, Matt Godbolt
+// Copyright (c) 2013-2026, Matt Godbolt and Nguyen Tran
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/main/c/AcceptEncoding.cpp
+++ b/src/main/c/AcceptEncoding.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2013-2017, Matt Godbolt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "internal/AcceptEncoding.h"
+
+#include "seasocks/StringUtil.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+namespace seasocks {
+
+namespace {
+
+// the qvalue of an Accept-Encoding element, defaulting to 1 when the weight is
+// absent (RFC 9110 section 12.4.2) or unparseable
+double weightOf(const std::string& element, std::string::size_type separator) {
+    if (separator == std::string::npos) {
+        return 1.0;
+    }
+    auto weight = trimWhitespace(element.substr(separator + 1));
+    if (!caseInsensitiveSame(weight.substr(0, 2), "q=")) {
+        return 1.0;
+    }
+    try {
+        auto parsedWeight = std::stod(weight.substr(2));
+        // stod accepts "nan"/"inf" without throwing; treat those as unparseable too
+        return std::isfinite(parsedWeight) ? parsedWeight : 1.0;
+    } catch (const std::logic_error&) {
+        return 1.0;
+    }
+}
+
+} // namespace
+
+bool acceptsGzip(const std::string& acceptEncoding) {
+    // sentinel for a coding that is not in the header; valid qvalues are 0..1, never -1
+    constexpr double NotListed = -1.0;
+    double gzipWeight = NotListed;
+    double wildcardWeight = NotListed;
+    for (const auto& entry : split(acceptEncoding, ',')) {
+        auto semicolon = entry.find(';');
+        auto coding = trimWhitespace(entry.substr(0, semicolon));
+        if (caseInsensitiveSame(coding, "gzip")) {
+            gzipWeight = weightOf(entry, semicolon);
+        } else if (caseInsensitiveSame(coding, "*")) {
+            wildcardWeight = weightOf(entry, semicolon);
+        }
+    }
+    // use gzip's own weight if it is listed; otherwise fall back to the wildcard
+    if (gzipWeight != NotListed) {
+        return gzipWeight > 0.0;
+    }
+    return wildcardWeight > 0.0;
+}
+
+}

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -18,9 +18,11 @@ else()
 endif()
 
 add_library(seasocks ${SEASOCKS_LIBTYPE}
+        AcceptEncoding.cpp
         Connection.cpp
         HybiAccept.cpp
         HybiPacketDecoder.cpp
+        internal/AcceptEncoding.h
         internal/Base64.cpp
         internal/Base64.h
         internal/ConcreteResponse.h

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -23,6 +23,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "internal/AcceptEncoding.h"
 #include "internal/Config.h"
 #include "internal/Embedded.h"
 #include "internal/HeaderMap.h"
@@ -191,6 +192,13 @@ bool hasConnectionType(const std::string& connection, const std::string& type) {
             return true;
     }
     return false;
+}
+
+// 1xx, 204, 205 and 304 must carry no body (RFC 9110), so there is nothing to compress
+bool hasBody(seasocks::ResponseCode code) {
+    auto value = static_cast<int>(code);
+    return value >= 200 && code != seasocks::ResponseCode::NoContent &&
+           code != seasocks::ResponseCode::ResetContent && code != seasocks::ResponseCode::NotModified;
 }
 
 } // namespace
@@ -1011,6 +1019,12 @@ void Connection::begin(ResponseCode responseCode, TransferEncoding encoding) {
     if (_transferEncoding == TransferEncoding::Chunked) {
         bufferLine("Transfer-encoding: chunked");
     }
+    // an absent Accept-Encoding accepts any coding (RFC 9110 section 12.5.3)
+    bool clientAcceptsGzip = !hasHeader("Accept-Encoding") || acceptsGzip(getHeader("Accept-Encoding"));
+    // gzip only whole, raw-encoded bodies so the compressed Content-Length is known up front
+    _compressResponse = _server.server().getHttpCompressionEnabled() && _transferEncoding == TransferEncoding::Raw && hasBody(responseCode) && clientAcceptsGzip;
+    _responseBuffer.clear();
+    _heldContentLength.clear();
 }
 
 void Connection::header(const std::string& header, const std::string& value) {
@@ -1019,10 +1033,37 @@ void Connection::header(const std::string& header, const std::string& value) {
         LS_ERROR(_logger, "header() called when in wrong state");
         return;
     }
+    // the handler already encoded the body, so stop compressing and restore the
+    // uncompressed length we held back, leaving the handler's headers and body untouched
+    if (_compressResponse && caseInsensitiveSame(header, "Content-Encoding")) {
+        _compressResponse = false;
+        if (!_heldContentLength.empty()) {
+            bufferLine("Content-Length: " + _heldContentLength);
+        }
+    }
+    // the compressed size isn't known yet; hold the uncompressed length back and write
+    // the compressed one at finish (or restore it above if we end up not compressing)
+    if (_compressResponse && caseInsensitiveSame(header, "Content-Length")) {
+        _heldContentLength = value;
+        return;
+    }
     bufferLine(header + ": " + value);
 }
 void Connection::payload(const void* data, size_t size, bool flush) {
     _server.checkThread();
+    // buffer the body until finish(); headers stay open so we can add the gzip ones there
+    if (_compressResponse) {
+        // buffer the whole body; flush is not honoured because the body cannot be sent
+        // until finish() has compressed it and computed the gzip Content-Length
+        if (_state != State::SENDING_RESPONSE_HEADERS && _state != State::SENDING_RESPONSE_BODY) {
+            LS_ERROR(_logger, "payload() called when in wrong state");
+            return;
+        }
+        _state = State::SENDING_RESPONSE_BODY;
+        auto bytes = static_cast<const uint8_t*>(data);
+        _responseBuffer.insert(_responseBuffer.end(), bytes, bytes + size);
+        return;
+    }
     if (_state == State::SENDING_RESPONSE_HEADERS) {
         bufferLine("");
         _state = State::SENDING_RESPONSE_BODY;
@@ -1048,7 +1089,20 @@ void Connection::writeChunkHeader(size_t size) {
 
 void Connection::finish(bool keepConnectionOpen) {
     _server.checkThread();
-    if (_state == State::SENDING_RESPONSE_HEADERS) {
+    if (_compressResponse) {
+        // the body is complete now, so compress it and emit the gzip headers with the
+        // compressed length, then the compressed body; the shared tail below sends it
+        auto compressed = ZlibContext::gzip(_responseBuffer.data(), _responseBuffer.size());
+        bufferLine("Content-Encoding: gzip");
+        // the body depends on the request's Accept-Encoding, so a shared cache must
+        // keep a separate copy per Accept-Encoding value (RFC 9110 section 12.5.5)
+        bufferLine("Vary: Accept-Encoding");
+        bufferLine("Content-Length: " + toString(compressed.size()));
+        bufferLine("");
+        write(compressed.data(), compressed.size(), false);
+        _compressResponse = false;
+        _responseBuffer.clear();
+    } else if (_state == State::SENDING_RESPONSE_HEADERS) {
         bufferLine("");
     } else if (_state != State::SENDING_RESPONSE_BODY) {
         LS_ERROR(_logger, "finish() called when in wrong state");

--- a/src/main/c/Connection.cpp
+++ b/src/main/c/Connection.cpp
@@ -1092,7 +1092,8 @@ void Connection::finish(bool keepConnectionOpen) {
     if (_compressResponse) {
         // the body is complete now, so compress it and emit the gzip headers with the
         // compressed length, then the compressed body; the shared tail below sends it
-        auto compressed = ZlibContext::gzip(_responseBuffer.data(), _responseBuffer.size());
+        std::vector<uint8_t> compressed;
+        zlibContext.gzip(_responseBuffer.data(), _responseBuffer.size(), compressed);
         bufferLine("Content-Encoding: gzip");
         // the body depends on the request's Accept-Encoding, so a shared cache must
         // keep a separate copy per Accept-Encoding value (RFC 9110 section 12.5.5)

--- a/src/main/c/Server.cpp
+++ b/src/main/c/Server.cpp
@@ -728,6 +728,15 @@ void Server::setPerMessageDeflateEnabled(bool enabled) {
     _perMessageDeflateEnabled = enabled;
 }
 
+void Server::setHttpCompressionEnabled(bool enabled) {
+    if (!Config::deflateEnabled) {
+        LS_ERROR(_logger, "Ignoring request to enable HTTP compression as Seasocks was compiled without support");
+        return;
+    }
+    LS_INFO(_logger, "Setting HTTP compression to " << (enabled ? "enabled" : "disabled"));
+    _httpCompressionEnabled = enabled;
+}
+
 void Server::checkThread() const {
     auto thisTid = gettid();
     if (thisTid != _threadId) {

--- a/src/main/c/internal/AcceptEncoding.h
+++ b/src/main/c/internal/AcceptEncoding.h
@@ -23,35 +23,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "seasocks/ZlibContext.h"
+#pragma once
 
-#include <stdexcept>
+#include <string>
 
 namespace seasocks {
 
-struct ZlibContext::Impl {
-};
-
-ZlibContext::ZlibContext() {
-}
-
-ZlibContext::~ZlibContext() {
-}
-
-void ZlibContext::initialise(int, int, int) {
-    throw std::runtime_error("Not compiled with zlib support");
-}
-
-void ZlibContext::deflate(const uint8_t*, size_t, std::vector<uint8_t>&) {
-    throw std::runtime_error("Not compiled with zlib support");
-}
-
-bool ZlibContext::inflate(std::vector<uint8_t>&, std::vector<uint8_t>&, int&) {
-    throw std::runtime_error("Not compiled with zlib support");
-}
-
-std::vector<uint8_t> ZlibContext::gzip(const uint8_t*, size_t) {
-    throw std::runtime_error("Not compiled with zlib support");
-}
+// true if a gzip-encoded response is acceptable for the given Accept-Encoding value
+bool acceptsGzip(const std::string& acceptEncoding);
 
 }

--- a/src/main/c/internal/AcceptEncoding.h
+++ b/src/main/c/internal/AcceptEncoding.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017, Matt Godbolt
+// Copyright (c) 2013-2026, Matt Godbolt and Nguyen Tran
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/main/c/seasocks/Connection.h
+++ b/src/main/c/seasocks/Connection.h
@@ -218,6 +218,12 @@ private:
     bool _perMessageDeflate = false;
     ZlibContext zlibContext;
 
+    bool _compressResponse = false;
+    std::vector<uint8_t> _responseBuffer;
+    // the response's own Content-Length, held back while compressing so it can be
+    // restored if a handler-set Content-Encoding turns compression off
+    std::string _heldContentLength;
+
     void pickProtocol();
 
     enum class State {

--- a/src/main/c/seasocks/Server.h
+++ b/src/main/c/seasocks/Server.h
@@ -148,6 +148,11 @@ public:
         return _perMessageDeflateEnabled;
     }
 
+    void setHttpCompressionEnabled(bool enabled);
+    bool getHttpCompressionEnabled() {
+        return _httpCompressionEnabled;
+    }
+
     class Runnable {
     public:
         virtual ~Runnable() = default;
@@ -203,6 +208,7 @@ private:
 
     // Compression settings
     bool _perMessageDeflateEnabled = false;
+    bool _httpCompressionEnabled = false;
 
     struct WebSocketHandlerEntry {
         std::shared_ptr<WebSocket::Handler> handler;

--- a/src/main/c/seasocks/ZlibContext.cpp
+++ b/src/main/c/seasocks/ZlibContext.cpp
@@ -141,6 +141,58 @@ struct ZlibContext::Impl {
     }
 };
 
+struct ZlibContext::GzipImpl {
+    z_stream stream;
+    uint8_t buffer[16384] = {0};
+
+    GzipImpl() {
+        stream.zalloc = Z_NULL;
+        stream.zfree = Z_NULL;
+        stream.opaque = Z_NULL;
+        // window bits over 15 select gzip: 15 is the 32K window, +16 adds the gzip
+        // header and trailer instead of a zlib wrapper (zlib manual, deflateInit2)
+        int ret = ::deflateInit2(
+            &stream,
+            Z_DEFAULT_COMPRESSION,
+            Z_DEFLATED,
+            15 + 16,
+            8, // memLevel: zlib's default, no named constant like the level/strategy defaults
+            Z_DEFAULT_STRATEGY);
+        if (ret != Z_OK) {
+            throw std::runtime_error("error initialising zlib gzip deflater");
+        }
+    }
+
+    ~GzipImpl() {
+        ::deflateEnd(&stream);
+    }
+
+    // compress the whole input into one gzip stream (RFC 1952) for HTTP Content-Encoding;
+    // follows zlib's zpipe.c deflate idiom and throws on any zlib error
+    void gzip(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output) {
+        // reset reuses the persistent stream for each call instead of re-initialising it
+        if (::deflateReset(&stream) != Z_OK) {
+            throw std::runtime_error("error resetting zlib gzip deflater");
+        }
+
+        stream.next_in = const_cast<z_const Bytef*>(input);
+        stream.avail_in = static_cast<uInt>(inputLen);
+
+        // Z_FINISH says all the input is supplied; deflate writes the next part of the gzip
+        // stream into the buffer each pass, so loop and append until it returns Z_STREAM_END
+        int ret;
+        do {
+            stream.next_out = buffer;
+            stream.avail_out = sizeof(buffer);
+            ret = ::deflate(&stream, Z_FINISH);
+            if (ret != Z_OK && ret != Z_STREAM_END) {
+                throw std::runtime_error("error gzipping message");
+            }
+            output.insert(output.end(), buffer, buffer + sizeof(buffer) - stream.avail_out);
+        } while (ret != Z_STREAM_END);
+    }
+};
+
 ZlibContext::ZlibContext() = default;
 
 ZlibContext::~ZlibContext() = default;
@@ -157,51 +209,11 @@ bool ZlibContext::inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& out
     return _impl->inflate(input, output, zlibError);
 }
 
-// compress the whole input into one gzip stream (RFC 1952) for HTTP Content-Encoding;
-// follows zlib's zpipe.c deflate idiom and throws on any zlib error
-std::vector<uint8_t> ZlibContext::gzip(const uint8_t* input, size_t inputLen) {
-    z_stream stream;
-    stream.zalloc = Z_NULL;
-    stream.zfree = Z_NULL;
-    stream.opaque = Z_NULL;
-
-    // window bits over 15 select gzip: 15 is the 32K window, +16 adds the gzip
-    // header and trailer instead of a zlib wrapper (zlib manual, deflateInit2)
-    int ret = ::deflateInit2(
-        &stream,
-        Z_DEFAULT_COMPRESSION,
-        Z_DEFLATED,
-        15 + 16,
-        8, // memLevel: zlib's default, no named constant like the level/strategy defaults
-        Z_DEFAULT_STRATEGY);
-
-    if (ret != Z_OK) {
-        throw std::runtime_error("error initialising zlib gzip deflater");
+void ZlibContext::gzip(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output) {
+    if (!_gzip) {
+        _gzip = std::make_unique<GzipImpl>();
     }
-
-    stream.next_in = const_cast<z_const Bytef*>(input);
-    stream.avail_in = static_cast<uInt>(inputLen);
-
-    std::vector<uint8_t> output;
-    uint8_t buffer[16384];
-    // Z_FINISH says all the input is supplied; deflate writes the next part of the gzip
-    // stream into the buffer each pass, so loop and append until it returns Z_STREAM_END
-    do {
-        stream.next_out = buffer;
-        stream.avail_out = sizeof(buffer);
-
-        ret = ::deflate(&stream, Z_FINISH);
-
-        if (ret != Z_OK && ret != Z_STREAM_END) {
-            ::deflateEnd(&stream);
-            throw std::runtime_error("error gzipping message");
-        }
-
-        output.insert(output.end(), buffer, buffer + sizeof(buffer) - stream.avail_out);
-    } while (ret != Z_STREAM_END);
-
-    ::deflateEnd(&stream);
-    return output;
+    _gzip->gzip(input, inputLen, output);
 }
 
 }

--- a/src/main/c/seasocks/ZlibContext.cpp
+++ b/src/main/c/seasocks/ZlibContext.cpp
@@ -157,4 +157,51 @@ bool ZlibContext::inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& out
     return _impl->inflate(input, output, zlibError);
 }
 
+// compress the whole input into one gzip stream (RFC 1952) for HTTP Content-Encoding;
+// follows zlib's zpipe.c deflate idiom and throws on any zlib error
+std::vector<uint8_t> ZlibContext::gzip(const uint8_t* input, size_t inputLen) {
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+
+    // window bits over 15 select gzip: 15 is the 32K window, +16 adds the gzip
+    // header and trailer instead of a zlib wrapper (zlib manual, deflateInit2)
+    int ret = ::deflateInit2(
+        &stream,
+        Z_DEFAULT_COMPRESSION,
+        Z_DEFLATED,
+        15 + 16,
+        8, // memLevel: zlib's default, no named constant like the level/strategy defaults
+        Z_DEFAULT_STRATEGY);
+
+    if (ret != Z_OK) {
+        throw std::runtime_error("error initialising zlib gzip deflater");
+    }
+
+    stream.next_in = const_cast<z_const Bytef*>(input);
+    stream.avail_in = static_cast<uInt>(inputLen);
+
+    std::vector<uint8_t> output;
+    uint8_t buffer[16384];
+    // Z_FINISH says all the input is supplied; deflate writes the next part of the gzip
+    // stream into the buffer each pass, so loop and append until it returns Z_STREAM_END
+    do {
+        stream.next_out = buffer;
+        stream.avail_out = sizeof(buffer);
+
+        ret = ::deflate(&stream, Z_FINISH);
+
+        if (ret != Z_OK && ret != Z_STREAM_END) {
+            ::deflateEnd(&stream);
+            throw std::runtime_error("error gzipping message");
+        }
+
+        output.insert(output.end(), buffer, buffer + sizeof(buffer) - stream.avail_out);
+    } while (ret != Z_STREAM_END);
+
+    ::deflateEnd(&stream);
+    return output;
+}
+
 }

--- a/src/main/c/seasocks/ZlibContext.h
+++ b/src/main/c/seasocks/ZlibContext.h
@@ -21,6 +21,8 @@ public:
     // WARNING: inflate() alters input
     bool inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& output, int& zlibError);
 
+    static std::vector<uint8_t> gzip(const uint8_t* input, size_t inputLen);
+
 private:
     struct Impl;
     std::unique_ptr<Impl> _impl;

--- a/src/main/c/seasocks/ZlibContext.h
+++ b/src/main/c/seasocks/ZlibContext.h
@@ -21,11 +21,14 @@ public:
     // WARNING: inflate() alters input
     bool inflate(std::vector<uint8_t>& input, std::vector<uint8_t>& output, int& zlibError);
 
-    static std::vector<uint8_t> gzip(const uint8_t* input, size_t inputLen);
+    void gzip(const uint8_t* input, size_t inputLen, std::vector<uint8_t>& output);
 
 private:
     struct Impl;
     std::unique_ptr<Impl> _impl;
+
+    struct GzipImpl;
+    std::unique_ptr<GzipImpl> _gzip;
 };
 
 } // namespace seasocks

--- a/src/main/c/seasocks/ZlibContextDisabled.cpp
+++ b/src/main/c/seasocks/ZlibContextDisabled.cpp
@@ -32,6 +32,9 @@ namespace seasocks {
 struct ZlibContext::Impl {
 };
 
+struct ZlibContext::GzipImpl {
+};
+
 ZlibContext::ZlibContext() {
 }
 
@@ -50,7 +53,7 @@ bool ZlibContext::inflate(std::vector<uint8_t>&, std::vector<uint8_t>&, int&) {
     throw std::runtime_error("Not compiled with zlib support");
 }
 
-std::vector<uint8_t> ZlibContext::gzip(const uint8_t*, size_t) {
+void ZlibContext::gzip(const uint8_t*, size_t, std::vector<uint8_t>&) {
     throw std::runtime_error("Not compiled with zlib support");
 }
 

--- a/src/test/c/CMakeLists.txt
+++ b/src/test/c/CMakeLists.txt
@@ -28,4 +28,9 @@ add_seasocks_executable(AllTests
 
 target_link_libraries(AllTests PRIVATE Catch2::Catch2WithMain Threads::Threads)
 
+if (DEFLATE_SUPPORT)
+    target_sources(AllTests PRIVATE HttpCompressionTests.cpp)
+    target_link_libraries(AllTests PRIVATE ZLIB::ZLIB)
+endif ()
+
 add_test(NAME AllTests COMMAND AllTests)

--- a/src/test/c/HttpCompressionTests.cpp
+++ b/src/test/c/HttpCompressionTests.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2013-2017, Matt Godbolt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "internal/AcceptEncoding.h"
+#include "seasocks/ZlibContext.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <zlib.h>
+
+#include <string>
+#include <vector>
+
+using namespace seasocks;
+
+namespace {
+
+// decompress a gzip stream (windowBits 15+16), to verify gzip() output round-trips
+std::string gunzip(const std::vector<uint8_t>& input) {
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.next_in = const_cast<z_const Bytef*>(input.data());
+    stream.avail_in = static_cast<uInt>(input.size());
+    REQUIRE(::inflateInit2(&stream, 15 + 16) == Z_OK);
+
+    std::string output;
+    uint8_t buffer[16384];
+    int ret;
+    do {
+        stream.next_out = buffer;
+        stream.avail_out = sizeof(buffer);
+        ret = ::inflate(&stream, Z_NO_FLUSH);
+        REQUIRE((ret == Z_OK || ret == Z_STREAM_END));
+        output.append(reinterpret_cast<char*>(buffer), sizeof(buffer) - stream.avail_out);
+    } while (ret != Z_STREAM_END);
+
+    ::inflateEnd(&stream);
+    return output;
+}
+
+} // namespace
+
+TEST_CASE("gzip helper round-trips", "[HttpCompressionTests]") {
+    std::string original(2000, 'x');
+    original += "some readable text to compress and check";
+    auto in = reinterpret_cast<const uint8_t*>(original.data());
+
+    auto compressed = ZlibContext::gzip(in, original.size());
+
+    // gzip stream starts with the magic bytes 1f 8b
+    REQUIRE(compressed.size() >= 2);
+    CHECK(compressed[0] == 0x1f);
+    CHECK(compressed[1] == 0x8b);
+    // a repetitive body must shrink
+    CHECK(compressed.size() < original.size());
+    // and it must decode back to exactly the input
+    CHECK(gunzip(compressed) == original);
+}
+
+TEST_CASE("empty body gzips to a valid stream", "[HttpCompressionTests]") {
+    auto compressed = ZlibContext::gzip(nullptr, 0);
+    CHECK(compressed[0] == 0x1f);
+    CHECK(compressed[1] == 0x8b);
+    CHECK(gunzip(compressed).empty());
+}
+
+TEST_CASE("acceptsGzip honours the Accept-Encoding value", "[HttpCompressionTests]") {
+    SECTION("gzip listed with a positive or default weight is acceptable") {
+        CHECK(acceptsGzip("gzip"));
+        CHECK(acceptsGzip("gzip, deflate, br"));
+        CHECK(acceptsGzip("GZIP"));
+        CHECK(acceptsGzip("gzip;q=0.5"));
+        CHECK(acceptsGzip("gzip; q=0.001"));
+        CHECK(acceptsGzip("br;q=1.0, gzip;q=0.8"));
+    }
+    SECTION("gzip with a zero weight is not acceptable") {
+        CHECK_FALSE(acceptsGzip("gzip;q=0"));
+        CHECK_FALSE(acceptsGzip("gzip;Q=0"));
+        CHECK_FALSE(acceptsGzip("gzip; q=0"));
+    }
+    SECTION("a malformed weight falls back to acceptable") {
+        CHECK(acceptsGzip("gzip;q="));
+        CHECK(acceptsGzip("gzip;q=abc"));
+        // stod parses these values without throwing; the finite-check keeps them lenient
+        CHECK(acceptsGzip("gzip;q=nan"));
+        CHECK(acceptsGzip("gzip;q=inf"));
+    }
+    SECTION("the wildcard applies only when gzip is not listed explicitly") {
+        CHECK(acceptsGzip("br, *"));
+        CHECK_FALSE(acceptsGzip("br, *;q=0"));
+        CHECK(acceptsGzip("gzip, *;q=0"));
+        CHECK_FALSE(acceptsGzip("gzip;q=0, *"));
+    }
+    SECTION("gzip absent without a usable wildcard is not acceptable") {
+        CHECK_FALSE(acceptsGzip("br, deflate"));
+        CHECK_FALSE(acceptsGzip(""));
+    }
+}

--- a/src/test/c/HttpCompressionTests.cpp
+++ b/src/test/c/HttpCompressionTests.cpp
@@ -69,7 +69,9 @@ TEST_CASE("gzip helper round-trips", "[HttpCompressionTests]") {
     original += "some readable text to compress and check";
     auto in = reinterpret_cast<const uint8_t*>(original.data());
 
-    auto compressed = ZlibContext::gzip(in, original.size());
+    ZlibContext context;
+    std::vector<uint8_t> compressed;
+    context.gzip(in, original.size(), compressed);
 
     // gzip stream starts with the magic bytes 1f 8b
     REQUIRE(compressed.size() >= 2);
@@ -82,10 +84,24 @@ TEST_CASE("gzip helper round-trips", "[HttpCompressionTests]") {
 }
 
 TEST_CASE("empty body gzips to a valid stream", "[HttpCompressionTests]") {
-    auto compressed = ZlibContext::gzip(nullptr, 0);
+    ZlibContext context;
+    std::vector<uint8_t> compressed;
+    context.gzip(nullptr, 0, compressed);
     CHECK(compressed[0] == 0x1f);
     CHECK(compressed[1] == 0x8b);
     CHECK(gunzip(compressed).empty());
+}
+
+TEST_CASE("gzip reuses one context across calls", "[HttpCompressionTests]") {
+    ZlibContext context;
+    const std::string first = "the first response body, repeated repeated repeated";
+    const std::string second = "an entirely different second body on the same context";
+    std::vector<uint8_t> a;
+    std::vector<uint8_t> b;
+    context.gzip(reinterpret_cast<const uint8_t*>(first.data()), first.size(), a);
+    context.gzip(reinterpret_cast<const uint8_t*>(second.data()), second.size(), b);
+    CHECK(gunzip(a) == first);
+    CHECK(gunzip(b) == second);
 }
 
 TEST_CASE("acceptsGzip honours the Accept-Encoding value", "[HttpCompressionTests]") {

--- a/src/test/c/HttpCompressionTests.cpp
+++ b/src/test/c/HttpCompressionTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017, Matt Godbolt
+// Copyright (c) 2013-2026, Matt Godbolt and Nguyen Tran
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Add gzip compression for HTTP responses payloads.
This addresses #88.

WebSockets already had per-message-deflate; this does the same kind of thing for Raw HTTP responses. Off by default, turn it on with `server.setHttpCompressionEnabled(true)` (mirrors `setPerMessageDeflateEnabled`).

What I added:

- new `ZlibContext::gzip()`: one-shot gzip of a whole buffer (windowBits 15+16, Z_FINISH)
- `Connection` buffer the Raw body, gzip it once in finish(), then send Content-Length (the compressed size) followed by the body. We need the size before the headers go out, so the whole body is buffered
- new `acceptsGzip()` parses `Accept-Encoding` per RFC 9110 12.5.3, decide whether the client accepts gzip, handling the special cases like q=0 and the * wildcard
- only Raw responses are compressed. Everything a PageHandler normally returns is Raw (textResponse/htmlResponse/jsonResponse/...), so this covers them.

A few edge cases:

- bodyless status codes (1xx, 204, 205, 304) are never gzipped
- if a handler already set its own `Content-Encoding`, I leave it alone and don't double-encode; its `Content-Length` is kept whatever order the headers arrive in
- compressed replies send `Vary: Accept-Encoding`: the body depends on the request's Accept-Encoding, so a shared cache must keep a separate copy per Accept-Encoding value (RFC 9110 section 12.5.5)


Tests in `HttpCompressionTests.cpp` cover the gzip round-trip, the empty body, and the `acceptsGzip` cases. Wired under `DEFLATE_SUPPORT` so the no-zlib build still compiles.

**Reference doc:**
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding
https://datatracker.ietf.org/doc/html/rfc1952
https://httpwg.org/specs/rfc9110.html#quality.values

**Reference for gzip and gunzip implementation**
https://www.zlib.net/zpipe.c
https://www.zlib.net/manual.html